### PR TITLE
DOC: require sphinx >= 3.0.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx >=3.0.0
 sphinx-audeering-theme >=0.9.0
 sphinx_autodoc_typehints


### PR DESCRIPTION
RTD installs a very old version of sphinx (<2.0), which is not compatible with `sphinx_autodoc_typehints`, see https://readthedocs.org/projects/audeer/builds/12143361/

So we force to use a newer version of sphinx.