### PR TITLE
DOC: show "Edit on Github" link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,4 +44,7 @@ html_theme_options = {
     'footer_links': False,
     'logo_only': False,
 }
+html_context = {
+    'display_github': True,
+}
 html_title = title


### PR DESCRIPTION
The default i setting is to show a link to Gitlab in the right corner of the docs, this changes the link to Github.