### PR TITLE
DOC: hide deprecated run_workers_thread

### DIFF
--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -74,11 +74,6 @@ run_tasks
 
 .. autofunction:: run_tasks
 
-run_worker_threads
-------------------
-
-.. autofunction:: run_worker_threads
-
 safe_path
 ---------
 


### PR DESCRIPTION
`run_workers_thread` is deprecated in favor of `run_tasks` and should be hidden from the docs.