### PR TITLE
TST: don't cover deprecated run_worker_threads

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -15,7 +15,7 @@ from audeer.core.tqdm import (
 
 # Exclude common_directory example from doctest on Windows
 # as it outputs a path in Linux syntax in the example
-if platform.system() == 'Windows':  # pragma: nocover
+if platform.system() == 'Windows':  # pragma: no cover
     __doctest_skip__ = ['common_directory']
 
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -204,7 +204,7 @@ def run_worker_threads(
         num_workers: int = None,
         progress_bar: bool = False,
         task_description: str = None
-) -> Sequence[Any]:
+) -> Sequence[Any]:  # pragma: no cover
     r"""Run parallel tasks using worker threads.
 
     .. note:: Result values are returned in order of ``params``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ addopts =
     --cov=audeer
     --cov-report term-missing
     --cov-report xml
-    --cov-fail-under=90
+    --cov-fail-under=100
 xfail_strict = true
 
 [flake8]


### PR DESCRIPTION
Removes deprecated `run_worker_threads` from coverage as we will not add an extra test for it.