### PR TITLE
Return members of archives in extract_archive(s)

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -175,7 +175,7 @@ def extract_archives(
         *,
         keep_archive: bool = True,
         verbose: bool = False,
-) -> typing.List:
+) -> typing.List[str]:
     r"""Extract ZIP or TAR.GZ archives.
 
     Args:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -103,7 +103,7 @@ def extract_archive(
         verbose: if ``True`` a progress bar is shown
 
     Returns:
-        members of archive
+        member filenames of archive
 
     Raises:
         RuntimeError: if the provided archive is not a ZIP or TAR.GZ file
@@ -136,6 +136,7 @@ def extract_archive(
                     for member in members:
                         zf.extract(member, destination)
                         pbar.update()
+                    member_names = [m.filename for m in members]
         elif archive.endswith('tar.gz'):
             with tarfile.open(archive, 'r') as tf:
                 members = tf.getmembers()
@@ -147,6 +148,7 @@ def extract_archive(
                     for member in members:
                         tf.extract(member, destination, numeric_owner=True)
                         pbar.update()
+                    member_names = [m.name for m in members]
         else:
             raise RuntimeError(
                 f'You can only extract ZIP and TAR.GZ files, '
@@ -164,7 +166,7 @@ def extract_archive(
     if not keep_archive:
         os.remove(archive)
 
-    return members
+    return member_names
 
 
 def extract_archives(
@@ -184,14 +186,14 @@ def extract_archives(
         verbose: if ``True`` a progress bar is shown
 
     Returns:
-        combined members of archives
+        combined member filenames of archives
 
     """
     with progress_bar(
         total=len(archives),
         disable=not verbose,
     ) as pbar:
-        members = []
+        member_names = []
         for archive in archives:
             desc = format_display_message(
                 f'Extract {os.path.basename(archive)}',
@@ -199,7 +201,7 @@ def extract_archives(
             )
             pbar.set_description_str(desc)
             pbar.refresh()
-            members += extract_archive(
+            member_names += extract_archive(
                 archive,
                 destination,
                 keep_archive=keep_archive,
@@ -207,7 +209,7 @@ def extract_archives(
             )
             pbar.update()
 
-    return members
+    return member_names
 
 
 def file_extension(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -92,7 +92,7 @@ def extract_archive(
         *,
         keep_archive: bool = True,
         verbose: bool = False,
-) -> typing.List:
+) -> typing.List[str]:
     r"""Extract a ZIP or TAR.GZ file.
 
     Args:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -92,7 +92,7 @@ def extract_archive(
         *,
         keep_archive: bool = True,
         verbose: bool = False,
-):
+) -> typing.List:
     r"""Extract a ZIP or TAR.GZ file.
 
     Args:
@@ -101,6 +101,9 @@ def extract_archive(
             Will be created if it doesn't exist
         keep_archive: if ``False`` delete archive file after extraction
         verbose: if ``True`` a progress bar is shown
+
+    Returns:
+        members of archive
 
     Raises:
         RuntimeError: if the provided archive is not a ZIP or TAR.GZ file
@@ -161,6 +164,8 @@ def extract_archive(
     if not keep_archive:
         os.remove(archive)
 
+    return members
+
 
 def extract_archives(
         archives: typing.Sequence[str],
@@ -168,7 +173,7 @@ def extract_archives(
         *,
         keep_archive: bool = True,
         verbose: bool = False,
-):
+) -> typing.List:
     r"""Extract ZIP or TAR.GZ archives.
 
     Args:
@@ -178,11 +183,15 @@ def extract_archives(
         keep_archive: if ``False`` delete archive files after extraction
         verbose: if ``True`` a progress bar is shown
 
+    Returns:
+        combined members of archives
+
     """
     with progress_bar(
         total=len(archives),
         disable=not verbose,
     ) as pbar:
+        members = []
         for archive in archives:
             desc = format_display_message(
                 f'Extract {os.path.basename(archive)}',
@@ -190,13 +199,15 @@ def extract_archives(
             )
             pbar.set_description_str(desc)
             pbar.refresh()
-            extract_archive(
+            members += extract_archive(
                 archive,
                 destination,
                 keep_archive=keep_archive,
                 verbose=False,
             )
             pbar.update()
+
+    return members
 
 
 def file_extension(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -49,14 +49,14 @@ def test_archives(tmpdir):
     for filename, member in zip(filenames, members):
         target_file = os.path.join(destination, f'{filename}.txt')
         assert os.path.exists(target_file)
-        assert os.path.basename(target_file) == member.filename
+        assert os.path.basename(target_file) == member
         os.remove(target_file)
 
     members = audeer.extract_archives(tar_files, destination)
     for filename, member in zip(filenames, members):
         target_file = os.path.join(destination, f'{filename}.txt')
         assert os.path.exists(target_file)
-        assert os.path.basename(target_file) == member.name
+        assert os.path.basename(target_file) == member
         os.remove(target_file)
 
     with pytest.raises(RuntimeError):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -45,16 +45,18 @@ def test_archives(tmpdir):
         tar_files.append(tar_file)
 
     # Extract archives
-    audeer.extract_archives(zip_files, destination)
-    for filename in filenames:
+    members = audeer.extract_archives(zip_files, destination)
+    for filename, member in zip(filenames, members):
         target_file = os.path.join(destination, f'{filename}.txt')
         assert os.path.exists(target_file)
+        assert os.path.basename(target_file) == member.filename
         os.remove(target_file)
 
-    audeer.extract_archives(tar_files, destination)
-    for filename in filenames:
+    members = audeer.extract_archives(tar_files, destination)
+    for filename, member in zip(filenames, members):
         target_file = os.path.join(destination, f'{filename}.txt')
         assert os.path.exists(target_file)
+        assert os.path.basename(target_file) == member.name
         os.remove(target_file)
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Closes #20 

This returns a list of members for `audeer.extract_archive()` and `audeer.extract_archives()`.
Now you can do:
```python
members = audeer.extract_archive()
```

What I don't like is that the returned objects depend on the underlying archive type.
E.g. when using a ZIP file we have 
```python
members[0].filename
```
whereas when it was a TAR.GZ archive we must use
```python
members[0].name
```

Which I find unfortunate.

Should we create our own archive object to abstract from the underlying objects, or just return filenames instead.

What was your use case for `members`?