### PR TITLE
Add audeer.deprecated_keyword_argument decorator

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -15,6 +15,7 @@ from audeer.core.tqdm import (
 )
 from audeer.core.utils import (
     deprecated,
+    deprecated_keyword_argument,
     flatten_list,
     freeze_requirements,
     uid,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -103,9 +103,9 @@ def deprecated_keyword_argument(
                     f"'{deprecated_argument}' argument is deprecated "
                     f"and will be removed with version {removal_version}."
                 )
+                argument_content = kwargs.pop(deprecated_argument)
                 if alternative_argument is not None:
                     message += f" Use '{alternative_argument}' instead."
-                    argument_content = kwargs.pop(deprecated_argument)
                     kwargs[alternative_argument] = argument_content
                 warnings.warn(
                     message,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -76,7 +76,7 @@ def deprecated_keyword_argument(
     You have to specify the version,
     for which the deprecated argument will be removed.
     The content assigned to ``deprecated_argument``
-    is passed on to the ``alternative_argument``.
+    is passed on to the ``new_argument``.
 
     Args:
         deprecated_argument: keyword argument to be marked as deprecated

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -65,7 +65,8 @@ def deprecated_keyword_argument(
         *,
         deprecated_argument: str,
         removal_version: str,
-        alternative_argument: str = None,
+        new_argument: str = None,
+        mapping: typing.Callable = None,
 ) -> Callable:
     r"""Mark keyword argument as deprecated.
 
@@ -80,12 +81,15 @@ def deprecated_keyword_argument(
     Args:
         deprecated_argument: keyword argument to be marked as deprecated
         removal_version: version the code will be removed
-        alternative_argument: keyword argument that should be used instead
+        new_argument: keyword argument that should be used instead
+        mapping: if the keyword argument is not only renamed,
+            but expects also different input values,
+            you can map to the new ones with this callable
 
     Example:
         >>> @deprecated_keyword_argument(
         ...     deprecated_argument='foo',
-        ...     alternative_argument='bar',
+        ...     new_argument='bar',
         ...     removal_version='2.0.0',
         ... )
         ... def function_with_new_argument(*, bar):
@@ -104,9 +108,12 @@ def deprecated_keyword_argument(
                     f"and will be removed with version {removal_version}."
                 )
                 argument_content = kwargs.pop(deprecated_argument)
-                if alternative_argument is not None:
-                    message += f" Use '{alternative_argument}' instead."
-                    kwargs[alternative_argument] = argument_content
+                if new_argument is not None:
+                    message += f" Use '{new_argument}' instead."
+                    if mapping is not None:
+                        kwargs[new_argument] = mapping(argument_content)
+                    else:
+                        kwargs[new_argument] = argument_content
                 warnings.warn(
                     message,
                     category=DeprecationWarning,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -74,8 +74,8 @@ def deprecated_keyword_argument(
 
     You have to specify the version,
     for which the deprecated argument will be removed.
-    The content assigned to the deprecated keyword argument
-    is passed on to the ``new_keyword_argument``.
+    The content assigned to ``deprecated_argument``
+    is passed on to the ``alternative_argument``.
 
     Args:
         deprecated_argument: keyword argument to be marked as deprecated

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -24,6 +24,11 @@ deprecated
 
 .. autofunction:: deprecated
 
+deprecated_keyword_argument
+---------------------------
+
+.. autofunction:: deprecated_keyword_argument
+
 extract_archive
 ---------------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,6 +58,80 @@ def test_deprecated():
         assert expected_message == str(w[-1].message)
 
 
+def test_deprecated_keyword_argument():
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='foo',
+        alternative_argument='bar',
+        removal_version='1.0.0',
+    )
+    def function_with_deprecated_keyword_argument(*, bar):
+        return bar
+
+    expected_message = (
+        "'foo' argument is deprecated "
+        "and will be removed with version 1.0.0."
+        " Use 'bar' instead."
+    )
+    value = 1
+    assert function_with_deprecated_keyword_argument(bar=value) == value
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Raise warning
+        r = function_with_deprecated_keyword_argument(foo=value)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert expected_message == str(w[-1].message)
+        assert r == value
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='foo',
+        removal_version='1.0.0',
+    )
+    def function_with_deprecated_keyword_argument(**kwargs):
+        return 1
+
+    expected_message = (
+        "'foo' argument is deprecated "
+        "and will be removed with version 1.0.0."
+    )
+    assert function_with_deprecated_keyword_argument() == 1
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Raise warning
+        r = function_with_deprecated_keyword_argument(foo=2)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert expected_message == str(w[-1].message)
+        assert r == 1
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='foo',
+        alternative_argument='bar',
+        removal_version='1.0.0',
+    )
+    class class_with_deprecated_keyword_argument(object):
+
+        def __init__(self, *, bar):
+            self.bar = bar
+
+    expected_message = (
+        "'foo' argument is deprecated "
+        "and will be removed with version 1.0.0."
+        " Use 'bar' instead."
+    )
+    value = 1
+    assert class_with_deprecated_keyword_argument(bar=value).bar == value
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Raise warning
+        r = class_with_deprecated_keyword_argument(foo=value)
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert expected_message == str(w[-1].message)
+        assert r.bar == value
+
+
 @pytest.mark.parametrize('nested_list,expected_list', [
     ([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]], [1, 2, 3, 4, 5]),
     ([[1, 2], 3], [1, 2, 3]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,8 +62,9 @@ def test_deprecated_keyword_argument():
 
     @audeer.deprecated_keyword_argument(
         deprecated_argument='foo',
-        alternative_argument='bar',
+        new_argument='bar',
         removal_version='1.0.0',
+        mapping=lambda x: 2 * x,
     )
     def function_with_deprecated_keyword_argument(*, bar):
         return bar
@@ -82,7 +83,7 @@ def test_deprecated_keyword_argument():
         r = function_with_deprecated_keyword_argument(foo=value)
         assert issubclass(w[-1].category, DeprecationWarning)
         assert expected_message == str(w[-1].message)
-        assert r == value
+        assert r == 2 * value
 
     @audeer.deprecated_keyword_argument(
         deprecated_argument='foo',
@@ -107,7 +108,7 @@ def test_deprecated_keyword_argument():
 
     @audeer.deprecated_keyword_argument(
         deprecated_argument='foo',
-        alternative_argument='bar',
+        new_argument='bar',
         removal_version='1.0.0',
     )
     class class_with_deprecated_keyword_argument(object):


### PR DESCRIPTION
This adds a decorator to mark keyword arguments as deprecated.

Example:
```python
import audeer


@audeer.deprecated_keyword_argument(
    deprecated_argument='foo',
    alternative_argument='bar',
    removal_version='1.0.0',
)   
def function_with_deprecated_keyword_argument(*, bar):
    return bar 
```