### PR TITLE
Switch to UserWarnings for deprecated decorators

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -55,7 +55,7 @@ def deprecated(
             )
             if alternative is not None:
                 message += f' Use {alternative} instead.'
-            warnings.warn(message, category=DeprecationWarning, stacklevel=2)
+            warnings.warn(message, category=UserWarning, stacklevel=2)
             return func(*args, **kwargs)
         return new_func
     return _deprecated
@@ -116,7 +116,7 @@ def deprecated_keyword_argument(
                         kwargs[new_argument] = argument_content
                 warnings.warn(
                     message,
-                    category=DeprecationWarning,
+                    category=UserWarning,
                     stacklevel=2,
                 )
             return func(*args, **kwargs)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,7 +22,7 @@ def test_deprecated():
         warnings.simplefilter("always")
         # Raise warning
         deprecated_function()
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
 
     @audeer.deprecated(removal_version='2.0.0')
@@ -38,7 +38,7 @@ def test_deprecated():
         warnings.simplefilter("always")
         # Raise warning
         deprecated_function()
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
 
     @audeer.deprecated(removal_version='2.0.0')
@@ -54,7 +54,7 @@ def test_deprecated():
         warnings.simplefilter("always")
         # Raise warning
         DeprecatedClass()
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
 
 
@@ -81,7 +81,7 @@ def test_deprecated_keyword_argument():
         warnings.simplefilter("always")
         # Raise warning
         r = function_with_deprecated_keyword_argument(foo=value)
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
         assert r == 2 * value
 
@@ -102,7 +102,7 @@ def test_deprecated_keyword_argument():
         warnings.simplefilter("always")
         # Raise warning
         r = function_with_deprecated_keyword_argument(foo=2)
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
         assert r == 1
 
@@ -128,7 +128,7 @@ def test_deprecated_keyword_argument():
         warnings.simplefilter("always")
         # Raise warning
         r = class_with_deprecated_keyword_argument(foo=value)
-        assert issubclass(w[-1].category, DeprecationWarning)
+        assert issubclass(w[-1].category, UserWarning)
         assert expected_message == str(w[-1].message)
         assert r.bar == value
 


### PR DESCRIPTION
Use `UserWarnings` instead of `DeprecationWarning` as the later ones are not shown in a default Python interpreter setting.