### PR TITLE
Add audeer.version_from_git()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -24,6 +24,7 @@ from audeer.core.utils import (
     run_worker_threads,
     to_list,
     uid,
+    version_from_git,
 )
 
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -449,13 +449,20 @@ def uid(
     return uid
 
 
-def version_from_git() -> str:
+def version_from_git(
+        *,
+        v=True,
+) -> str:
     r"""Get a version number from current git ref.
 
     The version is inferred executing
     ``git describe --tags --always``.
     If the command fails,
     ``'<unknown>'`` is returned.
+
+    Args:
+        v: if ``True`` version starts always with ``v``,
+            otherwise it never starts with ``v``
 
     Returns:
         version number
@@ -471,4 +478,8 @@ def version_from_git() -> str:
         version = version.decode().strip()
     except Exception:  # pragma: nocover
         version = '<unknown>'
+    if version.startswith('v') and not v:  # pragma: nocover (only local)
+        version = version[1:]
+    elif not version.startswith('v') and v:  # pragma: nocover (only github)
+        version = f'v{version}'
     return version

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -15,6 +15,9 @@ import warnings
 import audeer
 
 
+__doctest_skip__ = ['version_from_git']
+
+
 def deprecated(
         *,
         removal_version: str,
@@ -444,3 +447,28 @@ def uid(
         uid = uid.hexdigest()
         uid = f'{uid[0:8]}-{uid[8:12]}-{uid[12:16]}-{uid[16:20]}-{uid[20:]}'
     return uid
+
+
+def version_from_git() -> str:
+    r"""Get a version number from current git ref.
+
+    The version is inferred executing
+    ``git describe --tags --always``.
+    If the command fails,
+    ``'<unknown>'`` is returned.
+
+    Returns:
+        version number
+
+    Example:
+        >>> version_from_git()
+        'v1.0.0'
+
+    """
+    try:
+        git = ['git', 'describe', '--tags', '--always']
+        version = subprocess.check_output(git)
+        version = version.decode().strip()
+    except Exception:  # pragma: nocover
+        version = '<unknown>'
+    return version

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -103,3 +103,8 @@ uid
 ---
 
 .. autofunction:: uid
+
+version_from_git
+----------------
+
+.. autofunction:: version_from_git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,15 +1,12 @@
 from subprocess import check_output
 
+import audeer
+
 
 # Project -----------------------------------------------------------------
 project = 'audeer'
 author = 'Hagen Wierstorf, Johannes Wagner'
-# The x.y.z version read from tags
-try:
-    version = check_output(['git', 'describe', '--tags', '--always'])
-    version = version.decode().strip()
-except Exception:
-    version = '<unknown>'
+version = audeer.version_from_git()
 title = '{} Documentation'.format(project)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -272,5 +272,9 @@ def test_version_from_git():
     git = ['git', 'describe', '--tags', '--always']
     expected_version = subprocess.check_output(git)
     expected_version = expected_version.decode().strip()
-    version = audeer.version_from_git()
+    version = audeer.version_from_git(v=True)
+    if not expected_version.startswith('v'):
+        expected_version = f'v{expected_version}'
     assert version == expected_version
+    version = audeer.version_from_git(v=False)
+    assert version == expected_version[1:]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import warnings
 
 import pytest
@@ -265,3 +266,11 @@ def test_uid(from_string):
         assert uid == uid2
     else:
         assert uid != uid2
+
+
+def test_version_from_git():
+    git = ['git', 'describe', '--tags', '--always']
+    expected_version = subprocess.check_output(git)
+    expected_version = expected_version.decode().strip()
+    version = audeer.version_from_git()
+    assert version == expected_version


### PR DESCRIPTION
This adds a utility function that extracts a version number by the current git ref.
This will come handy for `audb.publish()` and can be used inside `docs/conf.py` to infer the current version for documentations.

It is not using a Python module to interact with git, but calls git directly which is easier and will not need another package.
If the command fails as `git` is not available or we are not inside a git repo, then `'<unknown>'` is returned as version.

Unfortunately, it is not that easy to write a test for this as it depends on the current stage of a git repo. So I repeated the code that should be executed in the test script.

![image](https://user-images.githubusercontent.com/173624/106022906-997f9b00-60c6-11eb-94b5-bca162e85262.png)
