### PR TITLE
Add audeer.git_tags()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -19,6 +19,7 @@ from audeer.core.utils import (
     deprecated_keyword_argument,
     flatten_list,
     freeze_requirements,
+    git_tags,
     is_uid,
     run_tasks,
     run_worker_threads,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -15,7 +15,7 @@ import warnings
 import audeer
 
 
-__doctest_skip__ = ['version_from_git']
+__doctest_skip__ = ['git_tags', 'version_from_git']
 
 
 def deprecated(
@@ -180,6 +180,45 @@ def freeze_requirements(outfile: str):
         _, err = p.communicate()
         if bool(p.returncode):
             raise RuntimeError(f'Freezing Python packages failed: {err}')
+
+
+def git_tags(
+        *,
+        v: bool = None,
+) -> typing.List:
+    r"""Get a list of available git tags.
+
+    The tags are inferred by executing
+    ``git tag`` in the current folder.
+    If the command fails,
+    an empty list is returned.
+
+    Args:
+        v: if ``True`` tags start always with ``v``,
+            if ``False`` they never start with ``v``,
+            if ``None`` the original tag names are returned
+
+    Returns:
+        list of tags
+
+    Example:
+        >>> git_tags()
+        ['v1.0.0', 'v1.1.0', 'v2.0.0']
+
+    """
+    try:
+        git = ['git', 'tag']
+        tags = subprocess.check_output(git)
+        tags = tags.decode().strip().split('\n')
+    except Exception:  # pragma: nocover
+        tags = []
+    if v is None:
+        return tags
+    if v:
+        tags = [f'v{t}' if not t.startswith('v') else t for t in tags]
+    else:
+        tags = [t[1:] if t.startswith('v') else t for t in tags]
+    return tags
 
 
 def is_uid(uid: str) -> bool:

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -451,7 +451,7 @@ def uid(
 
 def version_from_git(
         *,
-        v=True,
+        v: bool = True,
 ) -> str:
     r"""Get a version number from current git ref.
 

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -59,6 +59,11 @@ freeze_requirements
 
 .. autofunction:: freeze_requirements
 
+git_tags
+--------
+
+.. autofunction:: git_tags
+
 is_uid
 ------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,6 +159,24 @@ def test_freeze_requirements(tmpdir):
         audeer.freeze_requirements(outfile)
 
 
+def test_git_tags():
+    git = ['git', 'tag']
+    expected_tags = subprocess.check_output(git)
+    expected_tags = expected_tags.decode().strip().split('\n')
+    tags = audeer.git_tags()
+    assert tags == expected_tags
+    tags = audeer.git_tags(v=True)
+    expected_tags = [
+        f'v{t}' if not t.startswith('v') else t for t in expected_tags
+    ]
+    assert tags == expected_tags
+    tags = audeer.git_tags(v=False)
+    expected_tags = [
+        t[1:] if t.startswith('v') else t for t in expected_tags
+    ]
+    assert tags == expected_tags
+
+
 @pytest.mark.parametrize(
     'uid, expected',
     [


### PR DESCRIPTION
As discussed in https://github.com/audeering/audeer/pull/27#issuecomment-769681087, this adds a function `git_tags()` which returns a list of all available tags.

![image](https://user-images.githubusercontent.com/173624/106260839-23437b80-6221-11eb-87a3-82050f719add.png)
