### PR TITLE
Rename git functions

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -19,7 +19,7 @@ from audeer.core.utils import (
     deprecated_keyword_argument,
     flatten_list,
     freeze_requirements,
-    git_tags,
+    git_repo_tags,
     git_repo_version,
     is_uid,
     run_tasks,

--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -20,12 +20,12 @@ from audeer.core.utils import (
     flatten_list,
     freeze_requirements,
     git_tags,
+    git_repo_version,
     is_uid,
     run_tasks,
     run_worker_threads,
     to_list,
     uid,
-    version_from_git,
 )
 
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -15,7 +15,7 @@ import warnings
 import audeer
 
 
-__doctest_skip__ = ['git_tags', 'version_from_git']
+__doctest_skip__ = ['git_tags', 'git_repo_version']
 
 
 def deprecated(
@@ -219,6 +219,42 @@ def git_tags(
     else:
         tags = [t[1:] if t.startswith('v') else t for t in tags]
     return tags
+
+
+def git_repo_version(
+        *,
+        v: bool = True,
+) -> str:
+    r"""Get a version number from current git ref.
+
+    The version is inferred executing
+    ``git describe --tags --always``.
+    If the command fails,
+    ``'<unknown>'`` is returned.
+
+    Args:
+        v: if ``True`` version starts always with ``v``,
+            otherwise it never starts with ``v``
+
+    Returns:
+        version number
+
+    Example:
+        >>> git_repo_version()
+        'v1.0.0'
+
+    """
+    try:
+        git = ['git', 'describe', '--tags', '--always']
+        version = subprocess.check_output(git)
+        version = version.decode().strip()
+    except Exception:  # pragma: nocover
+        version = '<unknown>'
+    if version.startswith('v') and not v:  # pragma: nocover (only local)
+        version = version[1:]
+    elif not version.startswith('v') and v:  # pragma: nocover (only github)
+        version = f'v{version}'
+    return version
 
 
 def is_uid(uid: str) -> bool:
@@ -486,39 +522,3 @@ def uid(
         uid = uid.hexdigest()
         uid = f'{uid[0:8]}-{uid[8:12]}-{uid[12:16]}-{uid[16:20]}-{uid[20:]}'
     return uid
-
-
-def version_from_git(
-        *,
-        v: bool = True,
-) -> str:
-    r"""Get a version number from current git ref.
-
-    The version is inferred executing
-    ``git describe --tags --always``.
-    If the command fails,
-    ``'<unknown>'`` is returned.
-
-    Args:
-        v: if ``True`` version starts always with ``v``,
-            otherwise it never starts with ``v``
-
-    Returns:
-        version number
-
-    Example:
-        >>> version_from_git()
-        'v1.0.0'
-
-    """
-    try:
-        git = ['git', 'describe', '--tags', '--always']
-        version = subprocess.check_output(git)
-        version = version.decode().strip()
-    except Exception:  # pragma: nocover
-        version = '<unknown>'
-    if version.startswith('v') and not v:  # pragma: nocover (only local)
-        version = version[1:]
-    elif not version.startswith('v') and v:  # pragma: nocover (only github)
-        version = f'v{version}'
-    return version

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -15,7 +15,7 @@ import warnings
 import audeer
 
 
-__doctest_skip__ = ['git_tags', 'git_repo_version']
+__doctest_skip__ = ['git_repo_tags', 'git_repo_version']
 
 
 def deprecated(
@@ -182,7 +182,7 @@ def freeze_requirements(outfile: str):
             raise RuntimeError(f'Freezing Python packages failed: {err}')
 
 
-def git_tags(
+def git_repo_tags(
         *,
         v: bool = None,
 ) -> typing.List:
@@ -202,7 +202,7 @@ def git_tags(
         list of tags
 
     Example:
-        >>> git_tags()
+        >>> git_repo_tags()
         ['v1.0.0', 'v1.1.0', 'v2.0.0']
 
     """

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -59,10 +59,10 @@ freeze_requirements
 
 .. autofunction:: freeze_requirements
 
-git_tags
---------
+git_repo_tags
+-------------
 
-.. autofunction:: git_tags
+.. autofunction:: git_repo_tags
 
 git_repo_version
 ----------------

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -64,6 +64,11 @@ git_tags
 
 .. autofunction:: git_tags
 
+git_repo_version
+----------------
+
+.. autofunction:: git_repo_version
+
 is_uid
 ------
 
@@ -108,8 +113,3 @@ uid
 ---
 
 .. autofunction:: uid
-
-version_from_git
-----------------
-
-.. autofunction:: version_from_git

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@ import audeer
 # Project -----------------------------------------------------------------
 project = 'audeer'
 author = 'Hagen Wierstorf, Johannes Wagner'
-version = audeer.version_from_git()
+version = audeer.git_repo_version()
 title = '{} Documentation'.format(project)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -159,18 +159,18 @@ def test_freeze_requirements(tmpdir):
         audeer.freeze_requirements(outfile)
 
 
-def test_git_tags():
+def test_git_repo_tags():
     git = ['git', 'tag']
     expected_tags = subprocess.check_output(git)
     expected_tags = expected_tags.decode().strip().split('\n')
-    tags = audeer.git_tags()
+    tags = audeer.git_repo_tags()
     assert tags == expected_tags
-    tags = audeer.git_tags(v=True)
+    tags = audeer.git_repo_tags(v=True)
     expected_tags = [
         f'v{t}' if not t.startswith('v') else t for t in expected_tags
     ]
     assert tags == expected_tags
-    tags = audeer.git_tags(v=False)
+    tags = audeer.git_repo_tags(v=False)
     expected_tags = [
         t[1:] if t.startswith('v') else t for t in expected_tags
     ]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,6 +177,18 @@ def test_git_tags():
     assert tags == expected_tags
 
 
+def test_git_repo_version():
+    git = ['git', 'describe', '--tags', '--always']
+    expected_version = subprocess.check_output(git)
+    expected_version = expected_version.decode().strip()
+    version = audeer.git_repo_version(v=True)
+    if not expected_version.startswith('v'):
+        expected_version = f'v{expected_version}'
+    assert version == expected_version
+    version = audeer.git_repo_version(v=False)
+    assert version == expected_version[1:]
+
+
 @pytest.mark.parametrize(
     'uid, expected',
     [
@@ -284,15 +296,3 @@ def test_uid(from_string):
         assert uid == uid2
     else:
         assert uid != uid2
-
-
-def test_version_from_git():
-    git = ['git', 'describe', '--tags', '--always']
-    expected_version = subprocess.check_output(git)
-    expected_version = expected_version.decode().strip()
-    version = audeer.version_from_git(v=True)
-    if not expected_version.startswith('v'):
-        expected_version = f'v{expected_version}'
-    assert version == expected_version
-    version = audeer.version_from_git(v=False)
-    assert version == expected_version[1:]


### PR DESCRIPTION
Closes #29 

It renames:
* `git_tags()` to `git_repo_tags()`
* `version_from_git()` to `git_repo_version()`

![image](https://user-images.githubusercontent.com/173624/106273927-bd142400-6233-11eb-9dca-dd1076748bd3.png)

![image](https://user-images.githubusercontent.com/173624/106273954-c43b3200-6233-11eb-9a24-e190d23f4e86.png)
