### PR TITLE
Add audeer.is_semantic_version()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -21,6 +21,7 @@ from audeer.core.utils import (
     freeze_requirements,
     git_repo_tags,
     git_repo_version,
+    is_semantic_version,
     is_uid,
     run_tasks,
     run_worker_threads,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 from collections.abc import Iterable
 import copy
-from distutils.version import LooseVersion
 import functools
 import hashlib
 import queue

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 from collections.abc import Iterable
 import copy
+from distutils.version import LooseVersion
 import functools
 import hashlib
 import queue
@@ -255,6 +256,52 @@ def git_repo_version(
     elif not version.startswith('v') and v:  # pragma: nocover (only github)
         version = f'v{version}'
     return version
+
+
+def is_semantic_version(version: str) -> bool:
+    r"""Check if given string represents a semenatic version.
+
+    If the version strings starts with a ``'v'`` it is ignored.
+
+    Args:
+        version: version string
+
+    Returns:
+        ``True`` if version is a semantic version
+
+    Example:
+        >>> is_semantic_version('v1')
+        False
+        >>> is_semantic_version('1.2.3-r3')
+        True
+        >>> is_semantic_version('v0.7.2-9-g1572b37')
+        True
+
+    """
+    version_parts = version.split('.')
+
+    if len(version_parts) < 3:
+        return False
+
+    def is_integer_convertable(x):
+        try:
+            int(x)
+            return True
+        except ValueError:
+            return False
+
+    x, y, z = version_parts[:3]
+    # For Z, '-' are also allowed as separators
+    z = z.split('-')[0]
+    # Ignore starting 'v'
+    if x.startswith('v'):
+        x = x[1:]
+
+    for v in (x, y, z):
+        if not is_integer_convertable(v):
+            return False
+
+    return True
 
 
 def is_uid(uid: str) -> bool:

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -259,7 +259,9 @@ def git_repo_version(
 
 
 def is_semantic_version(version: str) -> bool:
-    r"""Check if given string represents a semenatic version.
+    r"""Check if given string represents a `semantic version`_.
+
+    .. _semantic version: https://semver.org
 
     Args:
         version: version string

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -261,8 +261,6 @@ def git_repo_version(
 def is_semantic_version(version: str) -> bool:
     r"""Check if given string represents a semenatic version.
 
-    If the version strings starts with a ``'v'`` it is ignored.
-
     Args:
         version: version string
 

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -69,6 +69,11 @@ git_repo_version
 
 .. autofunction:: git_repo_version
 
+is_semantic_version
+-------------------
+
+.. autofunction:: is_semantic_version
+
 is_uid
 ------
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -190,6 +190,59 @@ def test_git_repo_version():
 
 
 @pytest.mark.parametrize(
+    'version, is_semantic',
+    [
+        (
+            '1.0.0',
+            True,
+        ),
+        (
+            'v1.0.0',
+            True,
+        ),
+        (
+            '4.0.0-20200206.095534-3',
+            True,
+        ),
+        (
+            'v1.0.1-1-gdf29c4a',
+            True,
+        ),
+        (
+            '1',
+            False,
+        ),
+        (
+            'v1',
+            False,
+        ),
+        (
+            'v1.3-r3',
+            False,
+        ),
+        (
+            'v1.3.3-r3',
+            True,
+        ),
+        (
+            'a.b.c',
+            False,
+        ),
+        (
+            'va.b.c',
+            False,
+        ),
+        (
+            '1.2.a',
+            False,
+        ),
+    ]
+)
+def test_is_semantic_version(version, is_semantic):
+    assert audeer.is_semantic_version(version) == is_semantic
+
+
+@pytest.mark.parametrize(
     'uid, expected',
     [
         (audeer.uid(), True),


### PR DESCRIPTION
This adds `audeer.is_semantic_version()` to check that a given version number contains at least `X.Y.Z`, and that all those numbers are integers.

![image](https://user-images.githubusercontent.com/173624/107242397-3548c980-6a2c-11eb-8dff-7dc432ea56ae.png)
