### PR TITLE
Be more strict on semantic versions

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -309,6 +309,13 @@ def git_repo_version(
 def is_semantic_version(version: str) -> bool:
     r"""Check if given string represents a `semantic version`_.
 
+    Your version is allowed to start with a ``'v'``.
+    Otherwise it has to comply to ``'X.Y.Z'``,
+    where X, Y, Z are all integers.
+    Additional version information, like ``'beta'``
+    has to be added using a ``-``,
+    e.g. ``'X.Y.Z-beta'``.
+
     .. _semantic version: https://semver.org
 
     Args:
@@ -338,12 +345,17 @@ def is_semantic_version(version: str) -> bool:
         except ValueError:
             return False
 
-    x, y, z = version_parts[:3]
-    # For Z, '-' are also allowed as separators
-    z = z.split('-')[0]
+    x, y = version_parts[:2]
     # Ignore starting 'v'
     if x.startswith('v'):
         x = x[1:]
+
+    z = '.'.join(version_parts[2:])
+    # For Z, '-' are also allowed as separators,
+    # but you are not allowed to have an additonal '.' before
+    z = z.split('-')[0]
+    if len(z.split('.')) > 1:
+        return False
 
     for v in (x, y, z):
         if not is_integer_convertable(v):

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -309,12 +309,12 @@ def git_repo_version(
 def is_semantic_version(version: str) -> bool:
     r"""Check if given string represents a `semantic version`_.
 
-    Your version is allowed to start with a ``'v'``.
-    Otherwise it has to comply to ``'X.Y.Z'``,
+    Your version is allowed to start with a ``v``.
+    Otherwise it has to comply to ``X.Y.Z``,
     where X, Y, Z are all integers.
-    Additional version information, like ``'beta'``
+    Additional version information, like ``beta``
     has to be added using a ``-``,
-    e.g. ``'X.Y.Z-beta'``.
+    e.g. ``X.Y.Z-beta``.
 
     .. _semantic version: https://semver.org
 
@@ -351,9 +351,10 @@ def is_semantic_version(version: str) -> bool:
         x = x[1:]
 
     z = '.'.join(version_parts[2:])
-    # For Z, '-' are also allowed as separators,
+    # For Z, '-' and '+' are also allowed as separators,
     # but you are not allowed to have an additonal '.' before
     z = z.split('-')[0]
+    z = z.split('+')[0]
     if len(z.split('.')) > 1:
         return False
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -309,11 +309,10 @@ def git_repo_version(
 def is_semantic_version(version: str) -> bool:
     r"""Check if given string represents a `semantic version`_.
 
-    Your version is allowed to start with a ``v``.
-    Otherwise it has to comply to ``X.Y.Z``,
+    Your version has to comply to ``X.Y.Z`` or ``vX.Y.Z``,
     where X, Y, Z are all integers.
     Additional version information, like ``beta``
-    has to be added using a ``-``,
+    has to be added using a ``-`` or ``+``,
     e.g. ``X.Y.Z-beta``.
 
     .. _semantic version: https://semver.org

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -265,6 +265,10 @@ def test_git_repo_version():
             '1.2.a',
             False,
         ),
+        (
+            'v1.3.3.3-r3',
+            False,
+        ),
     ]
 )
 def test_is_semantic_version(version, is_semantic):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -269,6 +269,14 @@ def test_git_repo_version():
             'v1.3.3.3-r3',
             False,
         ),
+        (
+            '1.0.0+20130313144700',
+            True,
+        ),
+        (
+            '1.0.0-alpha+001',
+            True,
+        ),
     ]
 )
 def test_is_semantic_version(version, is_semantic):


### PR DESCRIPTION
This now allows only for `X.Y.Z-bla` or `X.Y.Z+bla`, where `bla` can be anything and might containa `.` as well.
Added also more documentation to the doc string.

![image](https://user-images.githubusercontent.com/173624/107255717-e6556100-6a38-11eb-81d3-1ef7afb548c9.png)
