### PR TITLE
DOC: add example to audeer.progress_bar()

### DIFF
--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -53,6 +53,31 @@ def progress_bar(
 ) -> tqdm:
     r"""Progress bar with optional text on the right.
 
+    If you want to show a constant description text
+    during presenting the prgress bar,
+    you can use it similar to:
+
+    .. code-block:: python
+
+        for file in progress_bar(files, desc='Copying'):
+            copy(file)
+
+    When the text should be updated as well,
+    you have to explicetly do that in each step:
+
+    .. code-block:: python
+
+        with progress_bar(files) as pbar:
+            for file in pbar:
+                desc = format_display_message(
+                    f'Copying {file}',
+                    pbar=True,
+                )
+                pbar.set_description_str(desc)
+                pbar.refresh()
+                copy(file)
+                pbar.update()
+
     Args:
         iterable: sequence to iterate through
         total: total number of iterations


### PR DESCRIPTION
As I find it hard to remember how to exactly use `audeer.progress_bar()` I added two examples to the docstring.
Before I didn't had an example as we can not easily execute it during building of the docs as the output is interactive.
But I decided now that it is more important to have an example as to make sure the code is executed.

The documentation now looks like this:

![image](https://user-images.githubusercontent.com/173624/114722092-ccd2dd00-9d39-11eb-81b7-808f431c6318.png)


