### PR TITLE
Add audeer.replace_file_extension()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -9,6 +9,7 @@ from audeer.core.io import (
     list_dir_names,
     list_file_names,
     mkdir,
+    replace_file_extension,
     safe_path,
 )
 from audeer.core.tqdm import (

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -384,6 +384,33 @@ def mkdir(
     return path
 
 
+def replace_file_extension(
+        path: typing.Union[str, bytes],
+        new_extension: str,
+) -> str:
+    """Replace file extension.
+
+    It uses :func:`audeer.file_extension`
+    to identify the current extension
+    and replaces it with ``new_extension``.
+
+    Args:
+        path: path to file
+        new_extension: new file extension
+
+    Returns:
+        path to file with new extension
+
+    Example:
+        >>> path = 'file.txt'
+        >>> replace_file_extension(path, 'rst')
+        'file.rst'
+
+    """
+    extension = file_extension(path)
+    return f'{path[:-len(extension)]}{new_extension}'
+
+
 def safe_path(
         path: typing.Union[str, bytes]
 ) -> str:

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -109,6 +109,11 @@ progress_bar
 
 .. autofunction:: progress_bar
 
+replace_file_extension
+----------------------
+
+.. autofunction:: replace_file_extension
+
 run_tasks
 ---------
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -338,3 +338,16 @@ def test_safe_path_symlinks(tmpdir):
     _, expected_path = os.path.splitdrive(expected_path)
     assert path == expected_path
     assert type(path) is str
+
+
+@pytest.mark.parametrize(
+    'path, new_extension, expected_path',
+    [
+        ('file.txt', 'wav', 'file.wav'),
+        ('test/file.txt', 'wav', 'test/file.wav'),
+        ('a/b/../file.txt', 'wav', 'a/b/../file.wav'),
+    ]
+)
+def test_replace_file_extension(path, new_extension, expected_path):
+    path = audeer.replace_file_extension(path, new_extension)
+    assert path == expected_path


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/173624/116070323-c6732800-a68c-11eb-9704-838a19ab4bf1.png)

This is the only path function that does not call `safe_path()` under the hood, but I think it makes more sense to not change the path here, but only the extension.