### PR TITLE
Add audeer.download_url()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -3,6 +3,7 @@ from audeer.core.io import (
     basename_wo_ext,
     common_directory,
     create_archive,
+    download_url,
     extract_archive,
     extract_archives,
     file_extension,

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -39,6 +39,11 @@ deprecated_keyword_argument
 
 .. autofunction:: deprecated_keyword_argument
 
+download_url
+------------
+
+.. autofunction:: download_url
+
 extract_archive
 ---------------
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -161,6 +161,14 @@ def test_common_directory(dirs, expected):
     assert common == expected
 
 
+def test_download_url(tmpdir):
+    url = 'https://audeering.github.io/audeer/_static/favicon.png'
+    audeer.download_url(url, tmpdir)
+    audeer.download_url(url, tmpdir)
+    dst = audeer.download_url(url, tmpdir, force_download=True)
+    assert dst == os.path.join(tmpdir, os.path.basename(url))
+
+
 @pytest.mark.parametrize('path,extension', [
     ('', ''),
     ('~/.bashrc', ''),


### PR DESCRIPTION
Add `audeer.download_url()` that uses `urllib.request` under the hood.
We had a similar implementation in https://github.com/audeering/audtorch/blob/21a745ff7fb6c16dd13823f1191e72971949abaa/audtorch/datasets/utils.py#L66-L107, and I think it might be useful to make this available in general.

![image](https://user-images.githubusercontent.com/173624/120323953-589ec980-c2e6-11eb-9f1e-9e7d53f3142a.png)
