### PR TITLE
CI: add test for macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.9
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest, windows-latest, macOS-latest ]
         python-version: [3.7, 3.8, 3.9]
 
     steps:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -15,6 +15,14 @@ from audeer.core.tqdm import (
 from audeer.core.utils import to_list
 
 
+# Exclude common_directory example from doctest
+# on Windows and MacOS
+# (which adds /System/Volumes/Data in front in the Github runner)
+# as it outputs a path in Linux syntax in the example
+if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
+    __doctest_skip__ = ['common_directory']
+
+
 def basename_wo_ext(
         path: typing.Union[str, bytes],
         *,
@@ -68,8 +76,8 @@ def common_directory(
         ...     '/home/user1/tmp/covert/operator',
         ...     '/home/user1/tmp/coven/members',
         ... ]
-        >>> common_directory(paths)  # doctest: +ELLIPSIS
-        '...tmp'
+        >>> common_directory(paths)
+        '/home/user1/tmp'
 
     """
     def all_names_equal(name):

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -69,7 +69,7 @@ def common_directory(
         ...     '/home/user1/tmp/coven/members',
         ... ]
         >>> common_directory(paths)  # doctest: +ELLIPSIS
-        '.../user1/tmp'
+        '...tmp'
 
     """
     def all_names_equal(name):

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -15,12 +15,6 @@ from audeer.core.tqdm import (
 from audeer.core.utils import to_list
 
 
-# Exclude common_directory example from doctest on Windows
-# as it outputs a path in Linux syntax in the example
-if platform.system() == 'Windows':  # pragma: no cover
-    __doctest_skip__ = ['common_directory']
-
-
 def basename_wo_ext(
         path: typing.Union[str, bytes],
         *,
@@ -74,8 +68,8 @@ def common_directory(
         ...     '/home/user1/tmp/covert/operator',
         ...     '/home/user1/tmp/coven/members',
         ... ]
-        >>> common_directory(paths)
-        '/home/user1/tmp'
+        >>> common_directory(paths)  # doctest: +ELLIPSIS
+        '.../user1/tmp'
 
     """
     def all_names_equal(name):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -159,6 +159,8 @@ def test_common_directory(dirs, expected):
     _, expected = os.path.splitdrive(expected)
     common = common.replace('\\', '/')
     expected = expected.replace('\\', '/')
+    # On MacOS we get a '/System/Volumes/Data' in front
+    common.replace('/System/Volumes/Data', '')
     assert common == expected
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -160,7 +160,7 @@ def test_common_directory(dirs, expected):
     common = common.replace('\\', '/')
     expected = expected.replace('\\', '/')
     # On MacOS we get a '/System/Volumes/Data' in front
-    common.replace('/System/Volumes/Data', '')
+    common = common.replace('/System/Volumes/Data', '')
     assert common == expected
 
 


### PR DESCRIPTION
Closes #46.

Add a test for macOS and restrict Windows and MacOS tests to Python 3.8.

I also disabled the docstring test for `audeer.common_directory()` under MacOS as it puts a `/System/Volumes/Data` in front of the path in the Github runner.