### PR TITLE
Add audeer.rmdir()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -11,6 +11,7 @@ from audeer.core.io import (
     list_file_names,
     mkdir,
     replace_file_extension,
+    rmdir,
     safe_path,
 )
 from audeer.core.tqdm import (

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -474,7 +474,7 @@ def rmdir(
         NotADirectoryError: if path is not a directory
 
     Example:
-        >>> p = mkdir('path1/path2/path3')
+        >>> mkdir('path1/path2/path3')  # doctest: +SKIP
         >>> rmdir('path1/path2')
         >>> list_dir_names('path1')
         []

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -458,6 +458,33 @@ def replace_file_extension(
     return f'{path[:-len(extension)]}{new_extension}'
 
 
+def rmdir(
+        path: typing.Union[str, bytes],
+):
+    """Remove directory.
+
+    Remove the directory
+    and all its content
+    if the directory exists.
+
+    Args:
+        path: absolute or relative path of directory to remove
+
+    Raises:
+        NotADirectoryError: if path is not a directory
+
+    Example:
+        >>> p = mkdir('path1/path2/path3')
+        >>> rmdir('path1/path2')
+        >>> list_dir_names('path1')
+        []
+
+    """
+    path = safe_path(path)
+    if os.path.exists(path):
+        shutil.rmtree(path)
+
+
 def safe_path(
         path: typing.Union[str, bytes]
 ) -> str:

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -119,6 +119,11 @@ replace_file_extension
 
 .. autofunction:: replace_file_extension
 
+rmdir
+-----
+
+.. autofunction:: rmdir
+
 run_tasks
 ---------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def cleanup():
+    yield
+    # Clean up after last test
+    files = ['favicon.png', os.path.join('path1', 'file1')]
+    folders = ['path1']
+    for file in files:
+        if os.path.exists(file):
+            os.remove(file)
+    for folder in folders:
+        if os.path.exists(folder):
+            os.rmdir(folder)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -308,6 +308,35 @@ def test_mkdir(tmpdir):
     assert mode != int('775', 8)
 
 
+def test_rmdir(tmpdir):
+    # Non existing dir
+    audeer.rmdir('non-esitent')
+    # Folder with file content
+    dir_tmp = tmpdir.mkdir('folder')
+    f = dir_tmp.join('file.txt')
+    f.write('')
+    path = str(dir_tmp)
+    p = audeer.mkdir(path)
+    with pytest.raises(NotADirectoryError):
+        audeer.rmdir(os.path.join(p, 'file.txt'))
+    audeer.rmdir(p)
+    assert not os.path.exists(p)
+    # Folder with folder content
+    path = str(tmpdir.mkdir('folder'))
+    p = audeer.mkdir(os.path.join(path, 'sub-folder'))
+    audeer.rmdir(os.path.dirname(p))
+    assert not os.path.exists(p)
+    assert not os.path.exists(os.path.dirname(p))
+    # Relative path
+    path = str(tmpdir.mkdir('folder'))
+    current_path = os.getcwd()
+    os.chdir(os.path.dirname(path))
+    assert os.path.exists(path)
+    audeer.rmdir('folder')
+    assert not os.path.exists(path)
+    os.chdir(current_path)
+
+
 @pytest.mark.parametrize('path', [
     ('~/.someconfigrc'),
     ('file.tar.gz'),


### PR DESCRIPTION
As I don't like to import `shutil` everytime I need to delete a directory and also first check if the directory exists, I decided to add `audeer.rmdir()`.

![image](https://user-images.githubusercontent.com/173624/142613601-1534be7d-86ae-4908-8016-d44ea0f993a6.png)
