### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,16 @@
 [metadata]
 name = audeer
 author = Hagen Wierstorf, Johannes Wagner
-author-email = hwierstorf@audeering.com, jwagner@audeering.com
+author_email = hwierstorf@audeering.com, jwagner@audeering.com
 maintainer = Hagen Wierstorf
-maintainer-email = hwierstorf@audeering.com
+maintainer_email = hwierstorf@audeering.com
 url = https://github.com/audeering/audeer/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audeer/
 description = Helpful Python functions
-long-description = file: README.rst
+long_description = file: README.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 platforms= any
 keywords = Python, tools
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.