### PR TITLE
Add audeer.touch()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -13,6 +13,7 @@ from audeer.core.io import (
     replace_file_extension,
     rmdir,
     safe_path,
+    touch,
 )
 from audeer.core.tqdm import (
     format_display_message,

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -373,10 +373,9 @@ def list_file_names(
         list of path(s) to file(s)
 
     Example:
-        >>> path = mkdir('path1')
-        >>> touch(os.path.join(path, 'file1'))  # doctest:+ELLIPSIS
-        '.../path1/file1'
-        >>> list_file_names(path, basenames=True)
+        >>> dir_path = mkdir('path1')
+        >>> file_path = touch(os.path.join(dir_path, 'file1'))
+        >>> list_file_names(dir_path, basenames=True)
         ['file1']
 
     """

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -524,6 +524,10 @@ def touch(
 ) -> str:
     """Create an empty file.
 
+    If the file exists already
+    it's access and modification times
+    are updated.
+
     Args:
         path: path to file
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -374,7 +374,8 @@ def list_file_names(
 
     Example:
         >>> path = mkdir('path1')
-        >>> open(os.path.join(path, 'file1'), 'a').close()
+        >>> touch(os.path.join(path, 'file1'))  # doctest:+ELLIPSIS
+        '.../path1/file1'
         >>> list_file_names(path, basenames=True)
         ['file1']
 
@@ -515,4 +516,29 @@ def safe_path(
         # Convert bytes to str, see https://stackoverflow.com/a/606199
         if type(path) == bytes:
             path = path.decode('utf-8').strip('\x00')
+    return path
+
+
+def touch(
+        path: typing.Union[str, bytes]
+) -> str:
+    """Create an empty file.
+
+    Args:
+        path: path to file
+
+    Returns:
+        expanded path to file
+
+    Example:
+        >>> path = touch('file.txt')
+        >>> os.path.basename(path)
+        'file.txt'
+
+    """
+    path = safe_path(path)
+    if os.path.exists(path):
+        os.utime(path, None)
+    else:
+        open(path, 'a').close()
     return path

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -373,10 +373,10 @@ def list_file_names(
         list of path(s) to file(s)
 
     Example:
-        >>> dir_path = mkdir('path1')
-        >>> file_path = touch(os.path.join(dir_path, 'file1'))
+        >>> dir_path = mkdir('path')
+        >>> file_path = touch(os.path.join(dir_path, 'file'))
         >>> list_file_names(dir_path, basenames=True)
-        ['file1']
+        ['file']
 
     """
     path = safe_path(path)

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -144,6 +144,11 @@ to_list
 
 .. autofunction:: to_list
 
+touch
+-----
+
+.. autofunction:: touch
+
 uid
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 def cleanup():
     yield
     # Clean up after last test
-    files = ['favicon.png', os.path.join('path1', 'file1')]
+    files = ['favicon.png', 'file.txt', os.path.join('path1', 'file1')]
     folders = ['path1']
     for file in files:
         if os.path.exists(file):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,13 @@ import pytest
 def cleanup():
     yield
     # Clean up after last test
-    files = ['favicon.png', 'file.txt', os.path.join('path1', 'file1')]
-    folders = ['path1']
+    files = [
+        'favicon.png',
+        'file.txt',
+        os.path.join('path', 'file'),
+        os.path.join('path1', 'file1'),
+    ]
+    folders = ['path', 'path1']
     for file in files:
         if os.path.exists(file):
             os.remove(file)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ import os
 import platform
 import stat
 import tarfile
+import time
 import zipfile
 
 import pytest
@@ -388,3 +389,19 @@ def test_safe_path_symlinks(tmpdir):
 def test_replace_file_extension(path, new_extension, expected_path):
     path = audeer.replace_file_extension(path, new_extension)
     assert path == expected_path
+
+
+def test_touch(tmpdir):
+    path = str(tmpdir.mkdir('folder1'))
+    path = audeer.mkdir(path)
+    path = os.path.join(path, 'file')
+    assert not os.path.exists(path)
+    audeer.touch(path)
+    assert os.path.exists(path)
+    stat = os.stat(path)
+    time.sleep(.1)
+    audeer.touch(path)
+    assert os.path.exists(path)
+    new_stat = os.stat(path)
+    assert stat.st_atime != new_stat.st_atime
+    assert stat.st_mtime != new_stat.st_mtime

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -403,5 +403,5 @@ def test_touch(tmpdir):
     audeer.touch(path)
     assert os.path.exists(path)
     new_stat = os.stat(path)
-    assert stat.st_atime != new_stat.st_atime
-    assert stat.st_mtime != new_stat.st_mtime
+    assert stat.st_atime < new_stat.st_atime
+    assert stat.st_mtime < new_stat.st_mtime


### PR DESCRIPTION
This adds `audeer.touch()` to create an empty file.
I think it is easier to remember and looks better as `open(path, 'a').close()`

![image](https://user-images.githubusercontent.com/173624/156149361-65e7dc13-4fc0-43f5-9f3e-71d5bdd9ca57.png)

I also use `audeer.touch()` now in the example for `audeer.list_file_names()`

![image](https://user-images.githubusercontent.com/173624/156196598-7d5aacad-4bb1-4588-867d-4642afc6f372.png)
