### PR TITLE
Add audeer.LooseVersion() and audeer.StrictVersion()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -38,7 +38,8 @@ from audeer.core.utils import (
     uid,
 )
 from audeer.core.version import (
-    Version,
+    LooseVersion,
+    StrictVersion,
 )
 
 

--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -37,6 +37,9 @@ from audeer.core.utils import (
     to_list,
     uid,
 )
+from audeer.core.version import (
+    Version,
+)
 
 
 # Discourage from audeer import *

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -1,7 +1,6 @@
 import concurrent.futures
 from collections.abc import Iterable
 import copy
-from distutils.version import LooseVersion
 import functools
 import hashlib
 import importlib
@@ -18,6 +17,7 @@ import uuid
 import warnings
 
 from audeer.core import tqdm
+from audeer.core.version import Version
 
 
 __doctest_skip__ = ['git_repo_tags', 'git_repo_version']
@@ -719,7 +719,7 @@ def sort_versions(
     def sort_key(value):
         if value.startswith('v'):
             value = value[1:]
-        return LooseVersion(value)
+        return Version(value)
 
     return sorted(versions, key=sort_key)
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -17,7 +17,7 @@ import uuid
 import warnings
 
 from audeer.core import tqdm
-from audeer.core.version import Version
+from audeer.core.version import LooseVersion
 
 
 __doctest_skip__ = ['git_repo_tags', 'git_repo_version']
@@ -719,7 +719,7 @@ def sort_versions(
     def sort_key(value):
         if value.startswith('v'):
             value = value[1:]
-        return Version(value)
+        return LooseVersion(value)
 
     return sorted(versions, key=sort_key)
 

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -3,26 +3,6 @@
 # and is licensed under
 # https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/LICENSE
 
-
-"""Provides classes to represent module version numbers (one class for
-each style of version numbering).  There are currently two such classes
-implemented: StrictVersion and LooseVersion.
-
-Every version number class implements the following interface:
-  * the 'parse' method takes a string and parses it to some internal
-    representation; if the string is an invalid version number,
-    'parse' raises a ValueError exception
-  * the class constructor takes an optional string argument which,
-    if supplied, is passed to 'parse'
-  * __str__ reconstructs the string that was passed to 'parse' (or
-    an equivalent string -- ie. one that will generate an equivalent
-    version number instance)
-  * __repr__ generates Python code to recreate the version number instance
-  * _cmp compares the current instance with either another instance
-    of the same class or a string (which will be parsed to an instance
-    of the same class, thus must follow the same rules)
-"""
-
 import re
 
 

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -6,6 +6,191 @@
 import re
 
 
+class Version:
+    """Abstract base class for version numbering classes."""
+
+    def __repr__(self):
+        return f"{self.__class__.__name__} ('{str(self)}')"
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        return c >= 0
+
+
+# Interface for version-number classes -- must be implemented
+# by the following classes (the concrete ones -- Version should
+# be treated as an abstract class).
+#    __init__ (string) - create and take same action as 'parse'
+#                        (string parameter is optional)
+#    parse (string)    - convert a string representation to whatever
+#                        internal representation is appropriate for
+#                        this style of version numbering
+#    __str__ (self)    - convert back to a string; should be very similar
+#                        (if not identical to) the string supplied to parse
+#    __repr__ (self)   - generate Python code to recreate
+#                        the instance
+#    _cmp (self, other) - compare two version numbers ('other' may
+#                        be an unparsed version string, or another
+#                        instance of your version class)
+
+
+class StrictVersion(Version):
+    """Version numbering for anal retentives and software idealists.
+
+    This implementation was originally part of :mod:`distutils`
+    as ``version.StrictVersion``.
+
+    A version number consists of two
+    or three dot-separated numeric components,
+    with an optional "pre-release" tag on the end.
+    The pre-release tag consists of the letter 'a' or 'b'
+    followed by a number.
+    If the numeric components of two version numbers are equal,
+    then one with a pre-release tag
+    will always be deemed earlier (lesser)
+    than one without.
+
+    The following are valid version numbers
+    (shown in the order
+    that would be obtained
+    by sorting according to the supplied cmp function):
+    ``'0.4'``,
+    ``'0.4.1'``,
+    ``'0.5a1'``,
+    ``'0.5b3'``,
+    ``'0.5'``,
+    ``'0.9.6'``,
+    ``'1.0'``,
+    ``'1.0.4a3'``,
+    ``'1.0.4b1'``,
+    ``'1.0.4'``.
+
+    The following are examples of invalid version numbers:
+    ``'1'``,
+    ``'2.7.2.2'``,
+    ``'1.3.a4'``,
+    ``'1.3pl1'``,
+    ``'1.3c4'``.
+
+    Args:
+        version: version string
+
+    Example:
+        >>> v1 = StrictVersion('1.17.2a1')
+        >>> v1
+        StrictVersion ('1.17.2a1')
+        >>> v1.version
+        (1, 17, 2)
+        >>> v1.prerelease
+        ('a', 1)
+        >>> v2 = StrictVersion('1.17.2')
+        >>> v1 < v2
+        True
+
+    """
+
+    version_re = re.compile(r'^(\d+) \. (\d+) (\. (\d+))? ([ab](\d+))?$',
+                            re.VERBOSE | re.ASCII)
+
+    def __init__(self, version=None):
+        self.version = None
+        r"Parsed version."
+        self.prerelease = None
+        r"Parsed prerelease part of version."
+
+        if version:
+            self.parse(version)
+
+    def parse(self, version):
+        r"""Parse a version string.
+
+        When called this updates the stored version
+        under ``self.version``.
+
+        Args:
+            version: version string
+
+        """
+        match = self.version_re.match(version)
+        if not match:
+            raise ValueError(f"invalid version number '{version}'")
+
+        (major, minor, patch, prerelease, prerelease_num) = \
+            match.group(1, 2, 4, 5, 6)
+
+        if patch:
+            self.version = tuple(map(int, [major, minor, patch]))
+        else:
+            self.version = tuple(map(int, [major, minor])) + (0,)
+
+        if prerelease:
+            self.prerelease = (prerelease[0], int(prerelease_num))
+        else:
+            self.prerelease = None
+
+    def __str__(self):
+
+        if self.version[2] == 0:
+            vstring = '.'.join(map(str, self.version[0:2]))
+        else:
+            vstring = '.'.join(map(str, self.version))
+
+        if self.prerelease:
+            vstring = vstring + self.prerelease[0] + str(self.prerelease[1])
+
+        return vstring
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = StrictVersion(other)
+        elif not isinstance(other, StrictVersion):
+            return NotImplemented
+
+        if self.version != other.version:
+            # numeric versions don't match
+            # prerelease stuff doesn't matter
+            if self.version < other.version:
+                return -1
+            else:
+                return 1
+
+        # have to compare prerelease
+        # case 1: neither has prerelease; they're equal
+        # case 2: self has prerelease, other doesn't; other is greater
+        # case 3: self doesn't have prerelease, other does: self is greater
+        # case 4: both have prerelease: must compare them!
+
+        if (not self.prerelease and not other.prerelease):
+            return 0
+        elif (self.prerelease and not other.prerelease):
+            return -1
+        elif (not self.prerelease and other.prerelease):
+            return 1
+        elif (self.prerelease and other.prerelease):
+            if self.prerelease == other.prerelease:
+                return 0
+            elif self.prerelease < other.prerelease:
+                return -1
+            else:
+                return 1
+
+
 # The rules according to Greg Stein:
 # 1) a version number has 1 or more numbers separated by a period or by
 #    sequences of letters. If only periods, then these are compared
@@ -14,7 +199,7 @@ import re
 #    compared lexicographically
 # 3) recognize the numeric components may have leading zeroes
 #
-# The Version class below implements these rules: a version number
+# The LooseVersion class below implements these rules: a version number
 # string is split up into a tuple of integer and string components, and
 # comparison is a simple tuple comparison.  This means that version
 # numbers behave in a predictable and obvious way, but a way that might
@@ -41,7 +226,7 @@ import re
 # "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
 # implemented here, this just isn't so.
 
-class Version:
+class LooseVersion(Version):
     r"""Version numbering for anarchists and software realists.
 
     This implementation was originally part of :mod:`distutils`
@@ -75,12 +260,12 @@ class Version:
         version: version string
 
     Example:
-        >>> v1 = Version('1.17.2')
+        >>> v1 = LooseVersion('1.17.2')
         >>> v1
-        Version ('1.17.2')
+        LooseVersion ('1.17.2')
         >>> v1.version
         [1, 17, 2]
-        >>> v2 = Version('1.17.2-3-g70b71bd')
+        >>> v2 = LooseVersion('1.17.2-3-g70b71bd')
         >>> v1 < v2
         True
 
@@ -114,9 +299,6 @@ class Version:
         c = self._cmp(other)
         return c >= 0
 
-    def __repr__(self):
-        return f"Version ('{str(self)}')"
-
     def __str__(self):
         return self.vstring
 
@@ -148,8 +330,8 @@ class Version:
 
     def _cmp(self, other):
         if isinstance(other, str):
-            other = Version(other)
-        elif not isinstance(other, Version):
+            other = LooseVersion(other)
+        elif not isinstance(other, LooseVersion):
             return NotImplemented
 
         if self.version == other.version:

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -140,7 +140,7 @@ class Version:
         self.version = None
         r"Parsed version."
 
-        if vstring:
+        if version:
             self.parse(version)
 
     def __eq__(self, other):
@@ -182,9 +182,9 @@ class Version:
         # I've given up on thinking I can reconstruct the version string
         # from the parsed tuple -- so I just store the string here for
         # use by __str__
-        self.vstring = vstring
+        self.vstring = version
         components = [
-            x for x in self.component_re.split(vstring)
+            x for x in self.component_re.split(version)
             if x and x != '.'
         ]
         for i, obj in enumerate(components):

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -91,7 +91,7 @@ import re
 # have a conception that matches common notions about version numbers.
 
 class Version:
-    """Version numbering for anarchists and software realists.
+    r"""Version numbering for anarchists and software realists.
 
     This implementation was originally part of :mod:`distutils`
     as ``version.LooseVersion``.
@@ -121,7 +121,7 @@ class Version:
     ``'2.0b1pl0'``,
 
     Args:
-        vstring: version string
+        version: version string
 
     Example:
         >>> v1 = Version('1.17.2')
@@ -136,9 +136,12 @@ class Version:
     """
     component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
 
-    def __init__(self, vstring=None):
+    def __init__(self, version=None):
+        self.version = None
+        r"Parsed version."
+
         if vstring:
-            self.parse(vstring)
+            self.parse(version)
 
     def __eq__(self, other):
         c = self._cmp(other)
@@ -166,7 +169,7 @@ class Version:
     def __str__(self):
         return self.vstring
 
-    def parse(self, vstring):
+    def parse(self, version):
         r"""Parse a version string.
 
         When called this updates the stored version
@@ -191,7 +194,6 @@ class Version:
                 pass
 
         self.version = components
-        """Parsed version."""
 
     def _cmp(self, other):
         if isinstance(other, str):

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -1,0 +1,207 @@
+# This code comes from
+# https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/Lib/distutils/tests/test_version.py
+# and is licensed under
+# https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/LICENSE
+
+
+"""Provides classes to represent module version numbers (one class for
+each style of version numbering).  There are currently two such classes
+implemented: StrictVersion and LooseVersion.
+
+Every version number class implements the following interface:
+  * the 'parse' method takes a string and parses it to some internal
+    representation; if the string is an invalid version number,
+    'parse' raises a ValueError exception
+  * the class constructor takes an optional string argument which,
+    if supplied, is passed to 'parse'
+  * __str__ reconstructs the string that was passed to 'parse' (or
+    an equivalent string -- ie. one that will generate an equivalent
+    version number instance)
+  * __repr__ generates Python code to recreate the version number instance
+  * _cmp compares the current instance with either another instance
+    of the same class or a string (which will be parsed to an instance
+    of the same class, thus must follow the same rules)
+"""
+
+import re
+
+
+# The rules according to Greg Stein:
+# 1) a version number has 1 or more numbers separated by a period or by
+#    sequences of letters. If only periods, then these are compared
+#    left-to-right to determine an ordering.
+# 2) sequences of letters are part of the tuple for comparison and are
+#    compared lexicographically
+# 3) recognize the numeric components may have leading zeroes
+#
+# The LooseVersion class below implements these rules: a version number
+# string is split up into a tuple of integer and string components, and
+# comparison is a simple tuple comparison.  This means that version
+# numbers behave in a predictable and obvious way, but a way that might
+# not necessarily be how people *want* version numbers to behave.  There
+# wouldn't be a problem if people could stick to purely numeric version
+# numbers: just split on period and compare the numbers as tuples.
+# However, people insist on putting letters into their version numbers;
+# the most common purpose seems to be:
+#   - indicating a "pre-release" version
+#     ('alpha', 'beta', 'a', 'b', 'pre', 'p')
+#   - indicating a post-release patch ('p', 'pl', 'patch')
+# but of course this can't cover all version number schemes, and there's
+# no way to know what a programmer means without asking him.
+#
+# The problem is what to do with letters (and other non-numeric
+# characters) in a version number.  The current implementation does the
+# obvious and predictable thing: keep them as strings and compare
+# lexically within a tuple comparison.  This has the desired effect if
+# an appended letter sequence implies something "post-release":
+# eg. "0.99" < "0.99pl14" < "1.0", and "5.001" < "5.001m" < "5.002".
+#
+# However, if letters in a version number imply a pre-release version,
+# the "obvious" thing isn't correct.  Eg. you would expect that
+# "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
+# implemented here, this just isn't so.
+#
+# Two possible solutions come to mind.  The first is to tie the
+# comparison algorithm to a particular set of semantic rules, as has
+# been done in the StrictVersion class above.  This works great as long
+# as everyone can go along with bondage and discipline.  Hopefully a
+# (large) subset of Python module programmers will agree that the
+# particular flavour of bondage and discipline provided by StrictVersion
+# provides enough benefit to be worth using, and will submit their
+# version numbering scheme to its domination.  The free-thinking
+# anarchists in the lot will never give in, though, and something needs
+# to be done to accommodate them.
+#
+# Perhaps a "moderately strict" version class could be implemented that
+# lets almost anything slide (syntactically), and makes some heuristic
+# assumptions about non-digits in version number strings.  This could
+# sink into special-case-hell, though; if I was as talented and
+# idiosyncratic as Larry Wall, I'd go ahead and implement a class that
+# somehow knows that "1.2.1" < "1.2.2a2" < "1.2.2" < "1.2.2pl3", and is
+# just as happy dealing with things like "2g6" and "1.13++".  I don't
+# think I'm smart enough to do it right though.
+#
+# In any case, I've coded the test suite for this module (see
+# ../test/test_version.py) specifically to fail on things like comparing
+# "1.2a2" and "1.2".  That's not because the *code* is doing anything
+# wrong, it's because the simple, obvious design doesn't match my
+# complicated, hairy expectations for real-world version numbers.  It
+# would be a snap to fix the test suite to say, "Yep, LooseVersion does
+# the Right Thing" (ie. the code matches the conception).  But I'd rather
+# have a conception that matches common notions about version numbers.
+
+class Version:
+    """Version numbering for anarchists and software realists.
+
+    This implementation was originally part of :mod:`distutils`
+    as ``version.LooseVersion``.
+
+    A version number consists of a series of numbers,
+    separated by either periods or strings of letters.
+    When comparing version numbers,
+    the numeric components will be compared numerically,
+    and the alphabetic components lexically.
+    The following are all valid version numbers,
+    in no particular order:
+    ``'1.5.1``,
+    ``'1.5.2b2``,
+    ``'161'``,
+    ``'3.10a'``,
+    ``'8.02'``,
+    ``'3.4j'``,
+    ``'1996.07.12'``,
+    ``'3.2.pl0'``,
+    ``'3.1.1.6'``,
+    ``'2g6'``,
+    ``'11g'``,
+    ``'0.960923'``,
+    ``'2.2beta29'``,
+    ``'1.13++'``,
+    ``'5.5.kw'``,
+    ``'2.0b1pl0'``,
+
+    Args:
+        vstring: version string
+
+    Example:
+        >>> v1 = Version('1.17.2')
+        >>> v1
+        Version ('1.17.2')
+        >>> v1.version
+        [1, 17, 2]
+        >>> v2 = Version('1.17.2-3-g70b71bd')
+        >>> v1 < v2
+        True
+
+    """
+    component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
+
+    def __init__(self, vstring=None):
+        if vstring:
+            self.parse(vstring)
+
+    def __eq__(self, other):
+        c = self._cmp(other)
+        return c == 0
+
+    def __lt__(self, other):
+        c = self._cmp(other)
+        return c < 0
+
+    def __le__(self, other):
+        c = self._cmp(other)
+        return c <= 0
+
+    def __gt__(self, other):
+        c = self._cmp(other)
+        return c > 0
+
+    def __ge__(self, other):
+        c = self._cmp(other)
+        return c >= 0
+
+    def __repr__(self):
+        return f"Version ('{str(self)}')"
+
+    def __str__(self):
+        return self.vstring
+
+    def parse(self, vstring):
+        r"""Parse a version string.
+
+        When called this updates the stored version
+        under ``self.version``.
+
+        Args:
+            version: version string
+
+        """
+        # I've given up on thinking I can reconstruct the version string
+        # from the parsed tuple -- so I just store the string here for
+        # use by __str__
+        self.vstring = vstring
+        components = [
+            x for x in self.component_re.split(vstring)
+            if x and x != '.'
+        ]
+        for i, obj in enumerate(components):
+            try:
+                components[i] = int(obj)
+            except ValueError:
+                pass
+
+        self.version = components
+        """Parsed version."""
+
+    def _cmp(self, other):
+        if isinstance(other, str):
+            other = Version(other)
+        elif not isinstance(other, Version):
+            return NotImplemented
+
+        if self.version == other.version:
+            return 0
+        if self.version < other.version:
+            return -1
+        if self.version > other.version:
+            return 1

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -118,7 +118,7 @@ class Version:
     ``'2.2beta29'``,
     ``'1.13++'``,
     ``'5.5.kw'``,
-    ``'2.0b1pl0'``,
+    ``'2.0b1pl0'``.
 
     Args:
         version: version string

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -14,7 +14,7 @@ import re
 #    compared lexicographically
 # 3) recognize the numeric components may have leading zeroes
 #
-# The LooseVersion class below implements these rules: a version number
+# The Version class below implements these rules: a version number
 # string is split up into a tuple of integer and string components, and
 # comparison is a simple tuple comparison.  This means that version
 # numbers behave in a predictable and obvious way, but a way that might
@@ -40,35 +40,6 @@ import re
 # the "obvious" thing isn't correct.  Eg. you would expect that
 # "1.5.1" < "1.5.2a2" < "1.5.2", but under the tuple/lexical comparison
 # implemented here, this just isn't so.
-#
-# Two possible solutions come to mind.  The first is to tie the
-# comparison algorithm to a particular set of semantic rules, as has
-# been done in the StrictVersion class above.  This works great as long
-# as everyone can go along with bondage and discipline.  Hopefully a
-# (large) subset of Python module programmers will agree that the
-# particular flavour of bondage and discipline provided by StrictVersion
-# provides enough benefit to be worth using, and will submit their
-# version numbering scheme to its domination.  The free-thinking
-# anarchists in the lot will never give in, though, and something needs
-# to be done to accommodate them.
-#
-# Perhaps a "moderately strict" version class could be implemented that
-# lets almost anything slide (syntactically), and makes some heuristic
-# assumptions about non-digits in version number strings.  This could
-# sink into special-case-hell, though; if I was as talented and
-# idiosyncratic as Larry Wall, I'd go ahead and implement a class that
-# somehow knows that "1.2.1" < "1.2.2a2" < "1.2.2" < "1.2.2pl3", and is
-# just as happy dealing with things like "2g6" and "1.13++".  I don't
-# think I'm smart enough to do it right though.
-#
-# In any case, I've coded the test suite for this module (see
-# ../test/test_version.py) specifically to fail on things like comparing
-# "1.2a2" and "1.2".  That's not because the *code* is doing anything
-# wrong, it's because the simple, obvious design doesn't match my
-# complicated, hairy expectations for real-world version numbers.  It
-# would be a snap to fix the test suite to say, "Yep, LooseVersion does
-# the Right Thing" (ie. the code matches the conception).  But I'd rather
-# have a conception that matches common notions about version numbers.
 
 class Version:
     r"""Version numbering for anarchists and software realists.

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -163,3 +163,9 @@ uid
 ---
 
 .. autofunction:: uid
+
+Version
+-------
+
+.. autoclass:: Version
+    :members:

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -109,6 +109,12 @@ list_file_names
 
 .. autofunction:: list_file_names
 
+LooseVersion
+------------
+
+.. autoclass:: LooseVersion
+    :members:
+    
 mkdir
 -----
 
@@ -149,6 +155,12 @@ sort_versions
 
 .. autofunction:: sort_versions
 
+StrictVersion
+-------------
+
+.. autoclass:: StrictVersion
+    :members:
+
 to_list
 -------
 
@@ -163,9 +175,3 @@ uid
 ---
 
 .. autofunction:: uid
-
-Version
--------
-
-.. autoclass:: Version
-    :members:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,58 @@
+import operator
+import pytest
+
+import audeer
+
+
+@pytest.mark.parametrize(
+    'v1, v2, wanted',
+    [
+        ('1.5.1', '1.5.2b2', -1),
+        ('161', '3.10a', 1),
+        ('8.02', '8.02', 0),
+        ('3.4j', '1996.07.12', -1),
+        ('3.2.pl0', '3.1.1.6', 1),
+        ('2g6', '11g', -1),
+        ('0.960923', '2.2beta29', -1),
+        ('1.13++', '5.5.kw', -1),
+    ]
+)
+def test_version(v1, v2, wanted):
+
+    v1 = audeer.Version(v1)
+
+    result = v1._cmp(audeer.Version(v2))
+    assert result == wanted
+
+    result = v1._cmp(v2)
+    assert result == wanted
+
+    result = v1._cmp(object())
+    assert result == NotImplemented
+
+    assert v1.__repr__() == f"Version ('{str(v1)}')"
+
+
+@pytest.mark.parametrize(
+    'v1, v2, operator, expected',
+    [
+        ('1.5.1', '1.5.2b2', operator.eq, False),
+        ('1.5.1', '1.5.2b2', operator.lt, True),
+        ('1.5.1', '1.5.2b2', operator.le, True),
+        ('1.5.1', '1.5.2b2', operator.gt, False),
+        ('1.5.1', '1.5.2b2', operator.ge, False),
+        ('1.5.1', '1.5.1', operator.eq, True),
+        ('1.5.1', '1.5.1', operator.le, True),
+        ('1.5.1', '1.5.1', operator.ge, True),
+        ('161', '3.10a', operator.gt, True),
+        ('8.02', '8.02', operator.eq, True),
+        ('3.4j', '1996.07.12', operator.lt, True),
+        ('3.2.pl0', '3.1.1.6', operator.gt, True),
+        ('2g6', '11g', operator.lt, True),
+        ('0.960923', '2.2beta29', operator.lt, True),
+        ('1.13++', '5.5.kw', operator.lt, True),
+    ]
+)
+def test_version_eq(v1, v2, operator, expected):
+    result = operator(audeer.Version(v1), audeer.Version(v2))
+    assert result == expected

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -19,6 +19,9 @@ import audeer
 )
 def test_version(v1, v2, wanted):
 
+    # This test is replicating the original tests from
+    # https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/Lib/distutils/tests/test_version.py
+
     v1 = audeer.Version(v1)
 
     result = v1._cmp(audeer.Version(v2))
@@ -53,6 +56,6 @@ def test_version(v1, v2, wanted):
         ('1.13++', '5.5.kw', operator.lt, True),
     ]
 )
-def test_version_eq(v1, v2, operator, expected):
+def test_version_operator(v1, v2, operator, expected):
     result = operator(audeer.Version(v1), audeer.Version(v2))
     assert result == expected

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -17,14 +17,14 @@ import audeer
         ('1.13++', '5.5.kw', -1),
     ]
 )
-def test_version(v1, v2, wanted):
+def test_loose_version(v1, v2, wanted):
 
     # This test is replicating the original tests from
     # https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/Lib/distutils/tests/test_version.py
 
-    v1 = audeer.Version(v1)
+    v1 = audeer.LooseVersion(v1)
 
-    result = v1._cmp(audeer.Version(v2))
+    result = v1._cmp(audeer.LooseVersion(v2))
     assert result == wanted
 
     result = v1._cmp(v2)
@@ -33,7 +33,7 @@ def test_version(v1, v2, wanted):
     result = v1._cmp(object())
     assert result == NotImplemented
 
-    assert v1.__repr__() == f"Version ('{str(v1)}')"
+    assert v1.__repr__() == f"LooseVersion ('{str(v1)}')"
 
 
 @pytest.mark.parametrize(
@@ -56,6 +56,106 @@ def test_version(v1, v2, wanted):
         ('1.13++', '5.5.kw', operator.lt, True),
     ]
 )
-def test_version_operator(v1, v2, operator, expected):
-    result = operator(audeer.Version(v1), audeer.Version(v2))
+def test_loose_version_operator(v1, v2, operator, expected):
+    v1 = audeer.LooseVersion(v1)
+    v2 = audeer.LooseVersion(v2)
+    result = operator(v1, v2)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'v1, v2, wanted',
+    [
+        ('1.5.1', '1.5.2b2', -1),
+        pytest.param(
+            '161',
+            '3.10a',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        ('8.02', '8.02', 0),
+        pytest.param(
+            '3.4j',
+            '1996.07.12',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            '3.2.pl0',
+            '3.1.1.6',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(
+            '2g6',
+            '11g',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        ('0.9', '2.2', -1),
+        ('1.2.1', '1.2', 1),
+        ('1.1', '1.2.2', -1),
+        ('1.2', '1.1', 1),
+        ('1.2.1', '1.2.2', -1),
+        ('1.2.2', '1.2', 1),
+        ('1.2', '1.2.2', -1),
+        ('0.4.0', '0.4', 0),
+        pytest.param(
+            '1.13++',
+            '5.5.kw',
+            None,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_strict_version(v1, v2, wanted):
+
+    # This test is replicating the original tests from
+    # https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/Lib/distutils/tests/test_version.py
+
+    v1 = audeer.StrictVersion(v1)
+
+    result = v1._cmp(audeer.StrictVersion(v2))
+    assert result == wanted
+
+    result = v1._cmp(v2)
+    assert result == wanted
+
+    result = v1._cmp(object())
+    assert result == NotImplemented
+
+    assert v1.__repr__() == f"StrictVersion ('{str(v1)}')"
+
+
+@pytest.mark.parametrize(
+    'v1, v2, operator, expected',
+    [
+        ('1.5.1', '1.5.2b2', operator.eq, False),
+        ('1.5.1', '1.5.2b2', operator.lt, True),
+        ('1.5.1', '1.5.2b2', operator.le, True),
+        ('1.5.1', '1.5.2b2', operator.gt, False),
+        ('1.5.1', '1.5.2b2', operator.ge, False),
+        ('1.5.1', '1.5.2b2', operator.ge, False),
+        ('1.5.1a1', '1.5.1', operator.lt, True),
+        ('1.5.1a1', '1.5.1a2', operator.lt, True),
+        ('1.5.1a2', '1.5.1a1', operator.gt, True),
+        ('1.5.1a1', '1.5.1a1', operator.eq, True),
+        ('1.5.1', '1.5.1b2', operator.gt, True),
+        ('1.5.1', '1.5.1', operator.le, True),
+        ('1.5.1', '1.5.1', operator.ge, True),
+        ('8.02', '8.02', operator.eq, True),
+        ('0.9', '2.2', operator.lt, True),
+        ('1.2.1', '1.2', operator.gt, True),
+        ('1.1', '1.2.2', operator.lt, True),
+        ('1.2', '1.1', operator.gt, True),
+        ('1.2.1', '1.2.2', operator.lt, True),
+        ('1.2.2', '1.2', operator.gt, True),
+        ('1.2', '1.2.2', operator.lt, True),
+        ('0.4.0', '0.4', operator.eq, True),
+    ]
+)
+def test_strict_version_operator(v1, v2, operator, expected):
+    v1 = audeer.StrictVersion(v1)
+    v2 = audeer.StrictVersion(v2)
+    result = operator(v1, v2)
     assert result == expected


### PR DESCRIPTION
Closes #55

This adds `audeer.LooseVersion` and `audeer.StrictVersion` copying the implementation of `distutils.version.LooseVersion` from https://github.com/python/cpython/blob/20a1c8ee4bcb1c421b7cca1f3f5d6ad7ce30a9c9/Lib/distutils/version.py

![image](https://user-images.githubusercontent.com/173624/156349733-acba4057-eb9c-4cc1-b1a7-5c50c30fdd2c.png)

![image](https://user-images.githubusercontent.com/173624/156350148-2db0264b-f62b-43b7-880f-ade548157d83.png)
