### PR TITLE
Possibility to join paths in audeer.safe_path()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -544,11 +544,12 @@ def safe_path(
 
     Args:
         path: path to file, directory
-        *paths: if additional arguments are provided,
-            they are first joined with :func:`os.path.join`
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
 
     Returns:
-        expanded path
+        (joined and) expanded path
 
     Example:
         >>> home = safe_path('~')

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -20,7 +20,11 @@ from audeer.core.utils import to_list
 # (which adds /System/Volumes/Data in front in the Github runner)
 # as it outputs a path in Linux syntax in the example
 if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
-    __doctest_skip__ = ['common_directory', 'list_file_names']
+    __doctest_skip__ = [
+        'common_directory',
+        'list_file_names',
+        'safe_path',
+    ]
 
 
 def basename_wo_ext(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -537,12 +537,15 @@ def rmdir(
 
 
 def safe_path(
-        path: typing.Union[str, bytes]
+        path: typing.Union[str, bytes],
+        *paths: typing.Sequence[typing.Union[str, bytes]],
 ) -> str:
     """Ensure the path is absolute and doesn't include `..` or `~`.
 
     Args:
         path: path to file, directory
+        *paths: if additional arguments are provided,
+            they are first joined with :func:`os.path.join`
 
     Returns:
         expanded path
@@ -552,8 +555,13 @@ def safe_path(
         >>> path = safe_path('~/path/.././path')
         >>> path[len(home) + 1:]
         'path'
+        >>> path = safe_path('~/path/.././path', './file.txt')
+        >>> path[len(home) + 1:]
+        'path/file.txt'
 
     """
+    if paths:
+        path = os.path.join(path, *paths)
     if path:
         path = os.path.realpath(os.path.expanduser(path))
         # Convert bytes to str, see https://stackoverflow.com/a/606199

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -494,6 +494,26 @@ def test_safe_path(path):
     assert type(path) is str
 
 
+@pytest.mark.parametrize(
+    'path, paths',
+    [
+        ('/a/b', ['file.tar.gz']),
+        ('/a', ['b', 'file.tar.gz']),
+        ('/a/c.d/g', ['../f']),
+        ('', ''),
+    ]
+)
+def test_safe_path_join(path, paths):
+    expected_path = os.path.join(path, *paths)
+    if expected_path:
+        expected_path = os.path.abspath(os.path.expanduser(expected_path))
+    else:
+        expected_path = ''
+    path = audeer.safe_path(path, *paths)
+    assert path == expected_path
+    assert type(path) is str
+
+
 def test_safe_path_symlinks(tmpdir):
     filename = 'file.txt'
     linkname = 'link.txt'


### PR DESCRIPTION
Closes #18.

This expands `audeer.safe_path()` by adding an optional `*paths` argument, which allows to provide parts of a path, which are then first joined by `os.path.join()`.

![image](https://user-images.githubusercontent.com/173624/156361047-74baa556-9a3c-4bf2-b9f2-370759044a57.png)
