### PR TITLE
Add audeer.path()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -11,12 +11,12 @@ from audeer.core.io import (
     list_file_names,
     mkdir,
     move_file,
-    path,
     replace_file_extension,
     rmdir,
     safe_path,
     touch,
 )
+from audeer.core.path import path
 from audeer.core.tqdm import (
     format_display_message,
     progress_bar,

--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -13,10 +13,12 @@ from audeer.core.io import (
     move_file,
     replace_file_extension,
     rmdir,
-    safe_path,
     touch,
 )
-from audeer.core.path import path
+from audeer.core.path import (
+    path,
+    safe_path,
+)
 from audeer.core.tqdm import (
     format_display_message,
     progress_bar,

--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -11,6 +11,7 @@ from audeer.core.io import (
     list_file_names,
     mkdir,
     move_file,
+    path,
     replace_file_extension,
     rmdir,
     safe_path,

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -24,6 +24,7 @@ if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
         'common_directory',
         'list_dir_names',
         'list_file_names',
+        'path',
         'safe_path',
     ]
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -8,7 +8,7 @@ import typing
 import urllib.request
 import zipfile
 
-from audeer.core.path import path as _path
+from audeer.core.path import path as safe_path
 from audeer.core.tqdm import (
     format_display_message,
     progress_bar,
@@ -25,7 +25,6 @@ if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
         'common_directory',
         'list_dir_names',
         'list_file_names',
-        'safe_path',
     ]
 
 
@@ -554,45 +553,6 @@ def rmdir(
     path = safe_path(path)
     if os.path.exists(path):
         shutil.rmtree(path)
-
-
-def safe_path(
-        path: typing.Union[str, bytes],
-        *paths: typing.Sequence[typing.Union[str, bytes]],
-) -> str:
-    """Expand and normalize to absolute path.
-
-    It uses :func:`os.path.realpath`
-    and :func:`os.path.expanduser`
-    to ensure an absolute path
-    without ``..`` or ``~``,
-    and independent of the path separator
-    of the operating system.
-
-    Warning:
-        :func:`audeer.safe_path` is deprecated,
-        please use :func:`audeer.path` instead.
-
-    Args:
-        path: path to file, directory
-        *paths: additional arguments
-            to be joined with ``path``
-            by :func:`os.path.join`
-
-    Returns:
-        (joined and) expanded path
-
-    Example:
-        >>> home = safe_path('~')
-        >>> folder = safe_path('~/path/.././path')
-        >>> folder[len(home) + 1:]
-        'path'
-        >>> file = safe_path('~/path/.././path', './file.txt')
-        >>> file[len(home) + 1:]
-        'path/file.txt'
-
-    """
-    return _path(path, *paths)
 
 
 def touch(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -8,6 +8,7 @@ import typing
 import urllib.request
 import zipfile
 
+from audeer.core.path import path as _path
 from audeer.core.tqdm import (
     format_display_message,
     progress_bar,
@@ -24,7 +25,6 @@ if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
         'common_directory',
         'list_dir_names',
         'list_file_names',
-        'path',
         'safe_path',
     ]
 
@@ -500,53 +500,6 @@ def move_file(
 
     """
     os.replace(src_path, dst_path)
-
-
-def path(
-        path: typing.Union[str, bytes],
-        *paths: typing.Sequence[typing.Union[str, bytes]],
-) -> str:
-    """Expand and normalize to absolute path.
-
-    It uses :func:`os.path.realpath`
-    and :func:`os.path.expanduser`
-    to ensure an absolute path
-    without ``..`` or ``~``,
-    and independent of the path separator
-    of the operating system.
-
-    Args:
-        path: path to file, directory
-        *paths: additional arguments
-            to be joined with ``path``
-            by :func:`os.path.join`
-
-    Returns:
-        (joined and) expanded path
-
-    Example:
-        >>> home = path('~')
-        >>> folder = path('~/path/.././path')
-        >>> folder[len(home) + 1:]
-        'path'
-        >>> file = path('~/path/.././path', './file.txt')
-        >>> file[len(home) + 1:]
-        'path/file.txt'
-
-    """
-    if paths:
-        path = os.path.join(path, *paths)
-    if path:
-        path = os.path.realpath(os.path.expanduser(path))
-        # Convert bytes to str, see https://stackoverflow.com/a/606199
-        if type(path) == bytes:
-            path = path.decode('utf-8').strip('\x00')
-    return path
-
-
-# Ensure function is not hidden
-# by `path` argument in `safe_path()`
-_path = path
 
 
 def replace_file_extension(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -507,7 +507,8 @@ def path(
 ) -> str:
     """Expand and normalize to absolute path.
 
-    It uses :func:`os.path.realpath` and `os.path.expanduser`
+    It uses :func:`os.path.realpath`
+    and :func:`os.path.expanduser`
     to ensure an absolute path
     without ``..`` or ``~``,
     and independent of the path separator
@@ -524,8 +525,8 @@ def path(
 
     Example:
         >>> home = path('~')
-        >>> dir = path('~/path/.././path')
-        >>> dir[len(home) + 1:]
+        >>> folder = path('~/path/.././path')
+        >>> folder[len(home) + 1:]
         'path'
         >>> file = path('~/path/.././path', './file.txt')
         >>> file[len(home) + 1:]
@@ -607,14 +608,15 @@ def safe_path(
 ) -> str:
     """Expand and normalize to absolute path.
 
-    It uses :func:`os.path.realpath` and `os.path.expanduser`
+    It uses :func:`os.path.realpath`
+    and :func:`os.path.expanduser`
     to ensure an absolute path
     without ``..`` or ``~``,
     and independent of the path separator
     of the operating system.
 
-    Note:
-        :func:audeer.safe_path` is deprecated,
+    Warning:
+        :func:`audeer.safe_path` is deprecated,
         please use :func:`audeer.path` instead.
 
     Args:
@@ -628,8 +630,8 @@ def safe_path(
 
     Example:
         >>> home = safe_path('~')
-        >>> dir = safe_path('~/path/.././path')
-        >>> dir[len(home) + 1:]
+        >>> folder = safe_path('~/path/.././path')
+        >>> folder[len(home) + 1:]
         'path'
         >>> file = safe_path('~/path/.././path', './file.txt')
         >>> file[len(home) + 1:]

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -10,6 +10,7 @@ import typing
 if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
     __doctest_skip__ = [
         'path',
+        'safe_path',
     ]
 
 
@@ -53,3 +54,47 @@ def path(
         if type(path) == bytes:
             path = path.decode('utf-8').strip('\x00')
     return path
+
+
+# Ensure function is not hidden
+# by `path` argument in `safe_path()`
+_path = path
+
+
+def safe_path(
+        path: typing.Union[str, bytes],
+        *paths: typing.Sequence[typing.Union[str, bytes]],
+) -> str:
+    """Expand and normalize to absolute path.
+
+    It uses :func:`os.path.realpath`
+    and :func:`os.path.expanduser`
+    to ensure an absolute path
+    without ``..`` or ``~``,
+    and independent of the path separator
+    of the operating system.
+
+    Warning:
+        :func:`audeer.safe_path` is deprecated,
+        please use :func:`audeer.path` instead.
+
+    Args:
+        path: path to file, directory
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
+
+    Returns:
+        (joined and) expanded path
+
+    Example:
+        >>> home = safe_path('~')
+        >>> folder = safe_path('~/path/.././path')
+        >>> folder[len(home) + 1:]
+        'path'
+        >>> file = safe_path('~/path/.././path', './file.txt')
+        >>> file[len(home) + 1:]
+        'path/file.txt'
+
+    """
+    return _path(path, *paths)

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -1,0 +1,55 @@
+import os
+import platform
+import typing
+
+
+# Exclude common_directory example from doctest
+# on Windows and MacOS
+# (which adds /System/Volumes/Data in front in the Github runner)
+# as it outputs a path in Linux syntax in the example
+if platform.system() in ['Darwin', 'Windows']:  # pragma: no cover
+    __doctest_skip__ = [
+        'path',
+    ]
+
+
+def path(
+        path: typing.Union[str, bytes],
+        *paths: typing.Sequence[typing.Union[str, bytes]],
+) -> str:
+    """Expand and normalize to absolute path.
+
+    It uses :func:`os.path.realpath`
+    and :func:`os.path.expanduser`
+    to ensure an absolute path
+    without ``..`` or ``~``,
+    and independent of the path separator
+    of the operating system.
+
+    Args:
+        path: path to file, directory
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
+
+    Returns:
+        (joined and) expanded path
+
+    Example:
+        >>> home = path('~')
+        >>> folder = path('~/path/.././path')
+        >>> folder[len(home) + 1:]
+        'path'
+        >>> file = path('~/path/.././path', './file.txt')
+        >>> file[len(home) + 1:]
+        'path/file.txt'
+
+    """
+    if paths:
+        path = os.path.join(path, *paths)
+    if path:
+        path = os.path.realpath(os.path.expanduser(path))
+        # Convert bytes to str, see https://stackoverflow.com/a/606199
+        if type(path) == bytes:
+            path = path.decode('utf-8').strip('\x00')
+    return path

--- a/docs/api-audeer.rst
+++ b/docs/api-audeer.rst
@@ -125,6 +125,11 @@ move_file
 
 .. autofunction:: move_file
 
+path
+----
+
+.. autofunction:: path
+
 progress_bar
 ------------
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -338,9 +338,7 @@ def test_list_file_names(tmpdir, files, path, filetype, file_list, recursive):
         audeer.mkdir(os.path.dirname(file_tmp))
         file_tmp.write('')
     if os.path.isdir(path):
-        file_list = [
-            audeer.safe_path(os.path.join(path, f)) for f in file_list
-        ]
+        file_list = [audeer.path(path, f) for f in file_list]
     else:
         file_list = [path]
     f = audeer.list_file_names(
@@ -461,6 +459,66 @@ def test_move_file(tmpdir, src_file, dst_file):
     assert os.path.exists(dst_path)
 
 
+@pytest.mark.parametrize('path', [
+    ('~/.someconfigrc'),
+    ('file.tar.gz'),
+    ('/a/c.d/g'),
+    ('/a/c.d/g.exe'),
+    ('../.././README.md'),
+    ('folder/file.txt'),
+    (b'folder/file.txt'),
+    (''),
+])
+def test_path(path):
+    if path:
+        expected_path = os.path.abspath(os.path.expanduser(path))
+    else:
+        expected_path = ''
+    if type(expected_path) == bytes:
+        expected_path = expected_path.decode('utf8')
+    path = audeer.path(path)
+    assert path == expected_path
+    assert type(path) is str
+
+
+@pytest.mark.parametrize(
+    'path, paths',
+    [
+        ('/a/b', ['file.tar.gz']),
+        ('/a', ['b', 'file.tar.gz']),
+        ('/a/c.d/g', ['../f']),
+        ('', ''),
+    ]
+)
+def test_path_join(path, paths):
+    expected_path = os.path.join(path, *paths)
+    if expected_path:
+        expected_path = os.path.abspath(os.path.expanduser(expected_path))
+    else:
+        expected_path = ''
+    path = audeer.path(path, *paths)
+    assert path == expected_path
+    assert type(path) is str
+
+
+def test_path_symlinks(tmpdir):
+    filename = 'file.txt'
+    linkname = 'link.txt'
+    dir_tmp = tmpdir.mkdir('folder')
+    f = dir_tmp.join(filename)
+    f.write('')
+    folder = audeer.mkdir(str(dir_tmp))
+    file = os.path.join(folder, filename)
+    link = os.path.join(folder, linkname)
+    os.symlink(file, link)
+    expected_path = os.path.realpath(os.path.expanduser(link))
+    path = audeer.path(link)
+    _, path = os.path.splitdrive(path)
+    _, expected_path = os.path.splitdrive(expected_path)
+    assert path == expected_path
+    assert type(path) is str
+
+
 def test_rmdir(tmpdir):
     # Non existing dir
     audeer.rmdir('non-esitent')
@@ -488,66 +546,6 @@ def test_rmdir(tmpdir):
     audeer.rmdir('folder')
     assert not os.path.exists(path)
     os.chdir(current_path)
-
-
-@pytest.mark.parametrize('path', [
-    ('~/.someconfigrc'),
-    ('file.tar.gz'),
-    ('/a/c.d/g'),
-    ('/a/c.d/g.exe'),
-    ('../.././README.md'),
-    ('folder/file.txt'),
-    (b'folder/file.txt'),
-    (''),
-])
-def test_safe_path(path):
-    if path:
-        expected_path = os.path.abspath(os.path.expanduser(path))
-    else:
-        expected_path = ''
-    if type(expected_path) == bytes:
-        expected_path = expected_path.decode('utf8')
-    path = audeer.safe_path(path)
-    assert path == expected_path
-    assert type(path) is str
-
-
-@pytest.mark.parametrize(
-    'path, paths',
-    [
-        ('/a/b', ['file.tar.gz']),
-        ('/a', ['b', 'file.tar.gz']),
-        ('/a/c.d/g', ['../f']),
-        ('', ''),
-    ]
-)
-def test_safe_path_join(path, paths):
-    expected_path = os.path.join(path, *paths)
-    if expected_path:
-        expected_path = os.path.abspath(os.path.expanduser(expected_path))
-    else:
-        expected_path = ''
-    path = audeer.safe_path(path, *paths)
-    assert path == expected_path
-    assert type(path) is str
-
-
-def test_safe_path_symlinks(tmpdir):
-    filename = 'file.txt'
-    linkname = 'link.txt'
-    dir_tmp = tmpdir.mkdir('folder')
-    f = dir_tmp.join(filename)
-    f.write('')
-    folder = audeer.mkdir(str(dir_tmp))
-    file = os.path.join(folder, filename)
-    link = os.path.join(folder, linkname)
-    os.symlink(file, link)
-    expected_path = os.path.realpath(os.path.expanduser(link))
-    path = audeer.safe_path(link)
-    _, path = os.path.splitdrive(path)
-    _, expected_path = os.path.splitdrive(expected_path)
-    assert path == expected_path
-    assert type(path) is str
 
 
 @pytest.mark.parametrize(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -459,66 +459,6 @@ def test_move_file(tmpdir, src_file, dst_file):
     assert os.path.exists(dst_path)
 
 
-@pytest.mark.parametrize('path', [
-    ('~/.someconfigrc'),
-    ('file.tar.gz'),
-    ('/a/c.d/g'),
-    ('/a/c.d/g.exe'),
-    ('../.././README.md'),
-    ('folder/file.txt'),
-    (b'folder/file.txt'),
-    (''),
-])
-def test_path(path):
-    if path:
-        expected_path = os.path.abspath(os.path.expanduser(path))
-    else:
-        expected_path = ''
-    if type(expected_path) == bytes:
-        expected_path = expected_path.decode('utf8')
-    path = audeer.path(path)
-    assert path == expected_path
-    assert type(path) is str
-
-
-@pytest.mark.parametrize(
-    'path, paths',
-    [
-        ('/a/b', ['file.tar.gz']),
-        ('/a', ['b', 'file.tar.gz']),
-        ('/a/c.d/g', ['../f']),
-        ('', ''),
-    ]
-)
-def test_path_join(path, paths):
-    expected_path = os.path.join(path, *paths)
-    if expected_path:
-        expected_path = os.path.abspath(os.path.expanduser(expected_path))
-    else:
-        expected_path = ''
-    path = audeer.path(path, *paths)
-    assert path == expected_path
-    assert type(path) is str
-
-
-def test_path_symlinks(tmpdir):
-    filename = 'file.txt'
-    linkname = 'link.txt'
-    dir_tmp = tmpdir.mkdir('folder')
-    f = dir_tmp.join(filename)
-    f.write('')
-    folder = audeer.mkdir(str(dir_tmp))
-    file = os.path.join(folder, filename)
-    link = os.path.join(folder, linkname)
-    os.symlink(file, link)
-    expected_path = os.path.realpath(os.path.expanduser(link))
-    path = audeer.path(link)
-    _, path = os.path.splitdrive(path)
-    _, expected_path = os.path.splitdrive(expected_path)
-    assert path == expected_path
-    assert type(path) is str
-
-
 def test_rmdir(tmpdir):
     # Non existing dir
     audeer.rmdir('non-esitent')

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -25,6 +25,9 @@ def test_path(path):
     path = audeer.path(path)
     assert path == expected_path
     assert type(path) is str
+    path = audeer.safe_path(path)
+    assert path == expected_path
+    assert type(path) is str
 
 
 @pytest.mark.parametrize(

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+
+import audeer
+
+
+@pytest.mark.parametrize('path', [
+    ('~/.someconfigrc'),
+    ('file.tar.gz'),
+    ('/a/c.d/g'),
+    ('/a/c.d/g.exe'),
+    ('../.././README.md'),
+    ('folder/file.txt'),
+    (b'folder/file.txt'),
+    (''),
+])
+def test_path(path):
+    if path:
+        expected_path = os.path.abspath(os.path.expanduser(path))
+    else:
+        expected_path = ''
+    if type(expected_path) == bytes:
+        expected_path = expected_path.decode('utf8')
+    path = audeer.path(path)
+    assert path == expected_path
+    assert type(path) is str
+
+
+@pytest.mark.parametrize(
+    'path, paths',
+    [
+        ('/a/b', ['file.tar.gz']),
+        ('/a', ['b', 'file.tar.gz']),
+        ('/a/c.d/g', ['../f']),
+        ('', ''),
+    ]
+)
+def test_path_join(path, paths):
+    expected_path = os.path.join(path, *paths)
+    if expected_path:
+        expected_path = os.path.abspath(os.path.expanduser(expected_path))
+    else:
+        expected_path = ''
+    path = audeer.path(path, *paths)
+    assert path == expected_path
+    assert type(path) is str
+
+
+def test_path_symlinks(tmpdir):
+    filename = 'file.txt'
+    linkname = 'link.txt'
+    dir_tmp = tmpdir.mkdir('folder')
+    f = dir_tmp.join(filename)
+    f.write('')
+    folder = audeer.mkdir(str(dir_tmp))
+    file = os.path.join(folder, filename)
+    link = os.path.join(folder, linkname)
+    os.symlink(file, link)
+    expected_path = os.path.realpath(os.path.expanduser(link))
+    path = audeer.path(link)
+    _, path = os.path.splitdrive(path)
+    _, expected_path = os.path.splitdrive(expected_path)
+    assert path == expected_path
+    assert type(path) is str


### PR DESCRIPTION
As suggested in https://github.com/audeering/audeer/pull/58#issuecomment-1056896331 this adds `audeer.path()`.
It also extends the docstring compared to what we had before in `audeer.safe_path()`.

![image](https://user-images.githubusercontent.com/173624/156400867-2b37adba-a0c1-4fe3-8088-1d22e2eaaf2d.png)

I added a warning to `audeer.safe_path()` in the documentation:

![image](https://user-images.githubusercontent.com/173624/156400945-874385ef-394b-4c9b-a25a-9052eea07089.png)
