### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
             python-version: 3.7
           - os: ubuntu-latest
             python-version: 3.9
+          - os: ubuntu-latest
+            python-version: 3.10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [3.8]
+        python-version: [ 3.8 ]
         include:
           - os: ubuntu-latest
             python-version: 3.7
           - os: ubuntu-latest
             python-version: 3.9
           - os: ubuntu-latest
-            python-version: 3.10
+            python-version: '3.10'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ 3.8 ]
+        python-version: [ '3.8' ]
         include:
           - os: ubuntu-latest
-            python-version: 3.7
+            python-version: '3.7'
           - os: ubuntu-latest
-            python-version: 3.9
+            python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.10'
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Utilities
 
 [options]


### PR DESCRIPTION
As Ubuntu 22.04 will be released soon and it does ship with Python 3.10, we should maybe start adding Python 3.10 to our open source repos.