### PR TITLE
Add remove_from_kwargs argument to deprecated_keyword_argument()

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -123,6 +123,7 @@ def deprecated_keyword_argument(
         removal_version: str,
         new_argument: str = None,
         mapping: typing.Callable = None,
+        remove_from_kwargs: bool = True,
 ) -> typing.Callable:
     r"""Mark keyword argument as deprecated.
 
@@ -141,6 +142,9 @@ def deprecated_keyword_argument(
         mapping: if the keyword argument is not only renamed,
             but expects also different input values,
             you can map to the new ones with this callable
+        remove_from_kwargs: if ``True``,
+            ``deprecated_argument`` will be removed
+            from ``kwargs`` inside the decorated object
 
     Example:
         >>> @deprecated_keyword_argument(
@@ -163,7 +167,10 @@ def deprecated_keyword_argument(
                     f"'{deprecated_argument}' argument is deprecated "
                     f"and will be removed with version {removal_version}."
                 )
-                argument_content = kwargs.pop(deprecated_argument)
+                if remove_from_kwargs:
+                    argument_content = kwargs.pop(deprecated_argument)
+                else:
+                    argument_content = kwargs[deprecated_argument]
                 if new_argument is not None:
                     message += f" Use '{new_argument}' instead."
                     if mapping is not None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,6 +138,31 @@ def test_deprecated_keyword_argument():
 
     @audeer.deprecated_keyword_argument(
         deprecated_argument='foo',
+        removal_version='1.0.0',
+        remove_from_kwargs=False,
+    )
+    def function_with_deprecated_keyword_argument(**kwargs):
+        if 'foo' in kwargs:
+            return kwargs['foo']
+        else:
+            return 1
+
+    expected_message = (
+        "'foo' argument is deprecated "
+        "and will be removed with version 1.0.0."
+    )
+    assert function_with_deprecated_keyword_argument() == 1
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Raise warning
+        r = function_with_deprecated_keyword_argument(foo=2)
+        assert issubclass(w[-1].category, UserWarning)
+        assert expected_message == str(w[-1].message)
+        assert r == 2
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='foo',
         new_argument='bar',
         removal_version='1.0.0',
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -165,6 +165,33 @@ def test_deprecated_keyword_argument():
         deprecated_argument='foo',
         new_argument='bar',
         removal_version='1.0.0',
+        remove_from_kwargs=False,
+    )
+    def function_with_deprecated_keyword_argument(**kwargs):
+        if 'foo' in kwargs:
+            return kwargs['foo']
+        else:
+            return 1
+
+    expected_message = (
+        "'foo' argument is deprecated "
+        "and will be removed with version 1.0.0."
+        " Use 'bar' instead."
+    )
+    assert function_with_deprecated_keyword_argument() == 1
+    with warnings.catch_warnings(record=True) as w:
+        # Cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+        # Raise warning
+        r = function_with_deprecated_keyword_argument(foo=2)
+        assert issubclass(w[-1].category, UserWarning)
+        assert expected_message == str(w[-1].message)
+        assert r == 2
+
+    @audeer.deprecated_keyword_argument(
+        deprecated_argument='foo',
+        new_argument='bar',
+        removal_version='1.0.0',
     )
     class class_with_deprecated_keyword_argument(object):
 


### PR DESCRIPTION
Closes #69 

This adds the keyword argument `remove_from_kwargs` to `audeer.deprecated_keyword_argument()` with default setting of `True`, which was the behavior before. If you set it to `False` it will not remove the deprecated keyword argument from `kwargs`.

![image](https://user-images.githubusercontent.com/173624/175492625-cbccdaf4-bc3e-4e97-8ba4-c77466787080.png)

