### PR TITLE
TST: depend on flake8<5.0.0

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest<7.0.0
 pytest-cov
 pytest-doctestplus


### PR DESCRIPTION
Newer version of flake8 do not work with the `pytest-flake8` plugin and will most likely not be fixed, see https://github.com/tholo/pytest-flake8/issues/87