### PR TITLE
DOC: add raises section for list_dir_names()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -353,6 +353,10 @@ def list_dir_names(
     Returns:
         list of paths to directories
 
+    Raises:
+        NotADirectoryError: if path is not a directory
+        FileNotFoundError: if path does not exists
+
     Example:
         >>> _ = mkdir('path/a/.b/c')
         >>> list_dir_names(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -254,6 +254,14 @@ def test_list_dir_names(tmpdir, dir_list, expected, recursive, hidden):
     assert dirs == expected
 
 
+def test_list_dir_names_errors(tmpdir):
+    with pytest.raises(NotADirectoryError):
+        file = audeer.touch(audeer.path(tmpdir, 'file.txt'))
+        audeer.list_dir_names(file)
+    with pytest.raises(FileNotFoundError):
+        audeer.list_dir_names('not-existent')
+
+
 @pytest.mark.parametrize(
     'files,path,filetype,expected,recursive,hidden',
     [


### PR DESCRIPTION
As mentioned in #76 `audeer.list_dir_names()` did not have documented or tested the cases where it raises an error.
This is changed here.

![image](https://user-images.githubusercontent.com/173624/208076378-2384fd1e-1209-4aff-8491-47e76db1e2d0.png)
