### PR TITLE
Add ext argument to replace_file_extension()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -580,16 +580,21 @@ def move_file(
 def replace_file_extension(
         path: typing.Union[str, bytes],
         new_extension: str,
+        *,
+        ext: str = None,
 ) -> str:
     """Replace file extension.
 
-    It uses :func:`audeer.file_extension`
+    If ``ext`` is ``None``
+    it uses :func:`audeer.file_extension`
     to identify the current extension
     and replaces it with ``new_extension``.
 
     Args:
         path: path to file
         new_extension: new file extension
+            without leading ``.``
+        ext: explicit extension to be removed
 
     Returns:
         path to file with new extension
@@ -598,10 +603,16 @@ def replace_file_extension(
         >>> path = 'file.txt'
         >>> replace_file_extension(path, 'rst')
         'file.rst'
+        >>> replace_file_extension('file.tar.gz', 'zip', ext='tar.gz')
+        'file.zip'
 
     """
-    extension = file_extension(path)
-    return f'{path[:-len(extension)]}{new_extension}'
+    print(f'{ext=}')
+    if ext is None:
+        ext = file_extension(path)
+    elif ext.startswith('.'):
+        ext = ext[1:]  # '.mp3' => 'mp3'
+    return f'{path[:-len(ext)]}{new_extension}'
 
 
 def rmdir(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -607,7 +607,6 @@ def replace_file_extension(
         'file.zip'
 
     """
-    print(f'{ext=}')
     if ext is None:
         ext = file_extension(path)
     elif ext.startswith('.'):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -609,6 +609,24 @@ def test_move_file(tmpdir, src_file, dst_file):
     assert os.path.exists(dst_path)
 
 
+@pytest.mark.parametrize(
+    'path, new_extension, ext, expected_path',
+    [
+        ('file.txt', 'wav', None, 'file.wav'),
+        ('test/file.txt', 'wav', None, 'test/file.wav'),
+        ('a/b/../file.txt', 'wav', None, 'a/b/../file.wav'),
+        ('file.txt', 'wav', 'txt', 'file.wav'),
+        ('file.txt', 'wav', '.txt', 'file.wav'),
+        ('file.txt', 'wav', 't', 'file.txwav'),
+        ('file.a.b', 'wav', 'a.b', 'file.wav'),
+        ('file.a.b', 'wav', '.a.b', 'file.wav'),
+    ]
+)
+def test_replace_file_extension(path, new_extension, ext, expected_path):
+    new_path = audeer.replace_file_extension(path, new_extension, ext=ext)
+    assert new_path == expected_path
+
+
 def test_rmdir(tmpdir):
     # Non existing dir
     audeer.rmdir('non-esitent')
@@ -636,19 +654,6 @@ def test_rmdir(tmpdir):
     audeer.rmdir('folder')
     assert not os.path.exists(path)
     os.chdir(current_path)
-
-
-@pytest.mark.parametrize(
-    'path, new_extension, expected_path',
-    [
-        ('file.txt', 'wav', 'file.wav'),
-        ('test/file.txt', 'wav', 'test/file.wav'),
-        ('a/b/../file.txt', 'wav', 'a/b/../file.wav'),
-    ]
-)
-def test_replace_file_extension(path, new_extension, expected_path):
-    path = audeer.replace_file_extension(path, new_extension)
-    assert path == expected_path
 
 
 def test_touch(tmpdir):


### PR DESCRIPTION
Closes #75 

The argument for the new extension is named `new_extension`, but I decided to use the name `ext` and not `extension` as we also have this argument in `audeer.basename_wo_ext()`.

![image](https://user-images.githubusercontent.com/173624/208085971-32570d54-93fa-455a-8335-49426f5f0990.png)
