### PR TITLE
TST: remove pytest-flake8 from requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 pytest<7.0.0
 pytest-cov
 pytest-doctestplus
-pytest-flake8


### PR DESCRIPTION
Remove unneeded `pytest-flake8` from `tests/requirements.txt`