### PR TITLE
Fix audeer.replace_file_extension() for empty extensions

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -598,6 +598,9 @@ def replace_file_extension(
     Returns:
         path to file with new extension
 
+    Raises:
+        RuntimeError: if ``path`` does not end on ``ext``
+
     Examples:
         >>> replace_file_extension('file.txt', 'rst')
         'file.rst'

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -599,7 +599,7 @@ def replace_file_extension(
         path to file with new extension
 
     Raises:
-        RuntimeError: if ``path`` does not end on ``ext``
+        RuntimeError: if ``path`` does not end on extension ``ext``
 
     Examples:
         >>> replace_file_extension('file.txt', 'rst')
@@ -621,8 +621,8 @@ def replace_file_extension(
     if new_extension.startswith('.'):
         new_extension = new_extension[1:]
 
-    if not path.endswith(ext):
-        msg = f"Path '{path}' does not end on '{ext}'"
+    if ext and not path.endswith(f'.{ext}'):
+        msg = f"Path '{path}' does not end on extension '{ext}'"
         raise RuntimeError(msg)
 
     if not path:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -593,25 +593,45 @@ def replace_file_extension(
     Args:
         path: path to file
         new_extension: new file extension
-            without leading ``.``
         ext: explicit extension to be removed
 
     Returns:
         path to file with new extension
 
     Examples:
-        >>> path = 'file.txt'
-        >>> replace_file_extension(path, 'rst')
+        >>> replace_file_extension('file.txt', 'rst')
         'file.rst'
+        >>> replace_file_extension('file', 'rst')
+        'file.rst'
+        >>> replace_file_extension('file.txt', '')
+        'file'
         >>> replace_file_extension('file.tar.gz', 'zip', ext='tar.gz')
         'file.zip'
 
     """
     if ext is None:
         ext = file_extension(path)
-    elif ext.startswith('.'):
-        ext = ext[1:]  # '.mp3' => 'mp3'
-    return f'{path[:-len(ext)]}{new_extension}'
+
+    # '.mp3' => 'mp3'
+    if ext.startswith('.'):
+        ext = ext[1:]
+    if new_extension.startswith('.'):
+        new_extension = new_extension[1:]
+
+    if not path.endswith(ext):
+        msg = f"Path '{path}' does not end on '{ext}'"
+        raise RuntimeError(msg)
+
+    if not ext and not new_extension:
+        pass
+    elif not ext:
+        path = f'{path}.{new_extension}'
+    elif not new_extension:
+        path = path[:-len(ext) - 1]
+    else:
+        path = f'{path[:-len(ext)]}{new_extension}'
+
+    return path
 
 
 def rmdir(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -590,16 +590,17 @@ def replace_file_extension(
     to identify the current extension
     and replaces it with ``new_extension``.
 
+    If ``ext`` is not ``None``
+    but ``path`` ends on a different extension,
+    the original path is returned.
+
     Args:
         path: path to file
         new_extension: new file extension
         ext: explicit extension to be removed
 
     Returns:
-        path to file with new extension
-
-    Raises:
-        RuntimeError: if ``path`` does not end on extension ``ext``
+        path to file with a possibly new extension
 
     Examples:
         >>> replace_file_extension('file.txt', 'rst')
@@ -609,6 +610,8 @@ def replace_file_extension(
         >>> replace_file_extension('file.txt', '')
         'file'
         >>> replace_file_extension('file.tar.gz', 'zip', ext='tar.gz')
+        'file.zip'
+        >>> replace_file_extension('file.zip', 'rst', ext='txt')
         'file.zip'
 
     """
@@ -622,8 +625,7 @@ def replace_file_extension(
         new_extension = new_extension[1:]
 
     if ext and not path.endswith(f'.{ext}'):
-        msg = f"Path '{path}' does not end on extension '{ext}'"
-        raise RuntimeError(msg)
+        return path
 
     if not path:
         return path

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -625,6 +625,9 @@ def replace_file_extension(
         msg = f"Path '{path}' does not end on '{ext}'"
         raise RuntimeError(msg)
 
+    if not path:
+        return path
+
     if not ext and not new_extension:
         pass
     elif not ext:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -611,7 +611,7 @@ def test_move_file(tmpdir, src_file, dst_file):
     'path, new_extension, ext, expected_path',
     [
         ('', '', None, ''),
-        ('', 'txt', None, '.txt'),
+        ('', 'txt', None, ''),
         ('file', '', None, 'file'),
         ('file', 'txt', None, 'file.txt'),
         ('file.txt', 'wav', None, 'file.wav'),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -621,7 +621,6 @@ def test_move_file(tmpdir, src_file, dst_file):
         ('file.txt', 'wav', '.txt', 'file.wav'),
         ('file.txt', '.wav', 'txt', 'file.wav'),
         ('file.txt', '.wav', '.txt', 'file.wav'),
-        ('file.txt', 'wav', 't', 'file.txwav'),
         ('file.a.b', 'wav', 'a.b', 'file.wav'),
         ('file.a.b', 'wav', '.a.b', 'file.wav'),
         pytest.param(
@@ -635,6 +634,13 @@ def test_move_file(tmpdir, src_file, dst_file):
             'file.txt',
             'wav',
             'bad',
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            'file.txt',
+            'wav',
+            't',
             None,
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -623,27 +623,9 @@ def test_move_file(tmpdir, src_file, dst_file):
         ('file.txt', '.wav', '.txt', 'file.wav'),
         ('file.a.b', 'wav', 'a.b', 'file.wav'),
         ('file.a.b', 'wav', '.a.b', 'file.wav'),
-        pytest.param(
-            'file',
-            'wav',
-            'bad',
-            None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
-        pytest.param(
-            'file.txt',
-            'wav',
-            'bad',
-            None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
-        pytest.param(
-            'file.txt',
-            'wav',
-            't',
-            None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
+        ('file', 'wav', 'ext', 'file'),
+        ('file.txt', 'wav', 'ext', 'file.txt'),
+        ('file.txt', 'wav', 't', 'file.txt'),
     ]
 )
 def test_replace_file_extension(path, new_extension, ext, expected_path):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -610,14 +610,34 @@ def test_move_file(tmpdir, src_file, dst_file):
 @pytest.mark.parametrize(
     'path, new_extension, ext, expected_path',
     [
+        ('', '', None, ''),
+        ('', 'txt', None, '.txt'),
+        ('file', '', None, 'file'),
+        ('file', 'txt', None, 'file.txt'),
         ('file.txt', 'wav', None, 'file.wav'),
         ('test/file.txt', 'wav', None, 'test/file.wav'),
         ('a/b/../file.txt', 'wav', None, 'a/b/../file.wav'),
         ('file.txt', 'wav', 'txt', 'file.wav'),
         ('file.txt', 'wav', '.txt', 'file.wav'),
+        ('file.txt', '.wav', 'txt', 'file.wav'),
+        ('file.txt', '.wav', '.txt', 'file.wav'),
         ('file.txt', 'wav', 't', 'file.txwav'),
         ('file.a.b', 'wav', 'a.b', 'file.wav'),
         ('file.a.b', 'wav', '.a.b', 'file.wav'),
+        pytest.param(
+            'file',
+            'wav',
+            'bad',
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            'file.txt',
+            'wav',
+            'bad',
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
     ]
 )
 def test_replace_file_extension(path, new_extension, ext, expected_path):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -612,6 +612,8 @@ def test_move_file(tmpdir, src_file, dst_file):
     [
         ('', '', None, ''),
         ('', 'txt', None, ''),
+        ('', '', 'rst', ''),
+        ('', 'txt', 'rst', ''),
         ('file', '', None, 'file'),
         ('file', 'txt', None, 'file.txt'),
         ('file.txt', 'wav', None, 'file.wav'),


### PR DESCRIPTION
Closes #89 #87 

Fixes #89 and #87 ~~and raises an error if `path` does not end on `ext`~~. For consistency with `ext`, `new_extension` may now also start with a dot.

![image](https://user-images.githubusercontent.com/10383417/215045005-559a4d6a-80b0-487d-b2e4-7c817d29a2c5.png)