### PR TITLE
Add support for short ID

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -489,7 +489,7 @@ def is_uid(uid: str) -> bool:
         ``True`` if string is a unique identifier
 
     Examples:
-        >>> is_uid(uid())
+        >>> is_uid('626f68e6-d336-70b9-e753-ed9fad855840')
         True
         >>> is_uid(uid(short=True))
         True

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -488,15 +488,34 @@ def is_uid(uid: str) -> bool:
     Returns:
         ``True`` if string is a unique identifier
 
+    Examples:
+        >>> is_uid(uid())
+        True
+        >>> is_uid(uid(short=True))
+        True
+        >>> is_uid('not a unique identifier')
+        False
+
     """
     if uid is None:
         return False
     if not isinstance(uid, str):
         return False
+    if len(uid) != 8 and len(uid) != 36:
+        return False
+
+    if len(uid) == 8:
+        uid = f'00000000-0000-0000-0000-0000{uid}'
+
+    for pos in [8, 13, 18, 23]:
+        if not uid[pos] == '-':
+            return False
+
     try:
         uuid.UUID(uid, version=1)
     except ValueError:
         return False
+
     return True
 
 
@@ -761,8 +780,14 @@ def to_list(x: typing.Any):
 def uid(
         *,
         from_string: str = None,
+        short: bool = False,
 ) -> str:
     r"""Generate unique identifier.
+
+    A unique identifier contains 36 characters
+    with ``-`` at position 9, 14, 19, 24.
+    If ``short`` is ``True``,
+    only the last 8 digits are returned.
 
     Args:
         from_string: create a unique identifier
@@ -770,14 +795,18 @@ def uid(
             This will return the same identifier
             for identical strings.
             If ``None`` :func:`uuid.uuid1` is used.
+        short: if ``True`` returns
+            a short unique identifier
+            (last 8 digits)
 
     Returns:
-        unique identifier containing 36 characters
-        with ``-`` at position 9, 14, 19, 24
+        unique identifier
 
     Examples:
         >>> uid(from_string='example_string')
         '626f68e6-d336-70b9-e753-ed9fad855840'
+        >>> uid(from_string='example_string', short=True)
+        'ad855840'
 
     """
     if from_string is None:
@@ -787,4 +816,8 @@ def uid(
         uid.update(from_string.encode('utf-8'))
         uid = uid.hexdigest()
         uid = f'{uid[0:8]}-{uid[8:12]}-{uid[12:16]}-{uid[16:20]}-{uid[20:]}'
+
+    if short:
+        uid = uid[-8:]
+
     return uid

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -491,7 +491,7 @@ def is_uid(uid: str) -> bool:
     Examples:
         >>> is_uid('626f68e6-d336-70b9-e753-ed9fad855840')
         True
-        >>> is_uid(uid(short=True))
+        >>> is_uid('ad855840')
         True
         >>> is_uid('not a unique identifier')
         False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -342,6 +342,7 @@ def test_is_semantic_version(version, is_semantic):
         (audeer.uid(short=True), True),
         (audeer.uid(from_string='from string'), True),
         (audeer.uid(from_string='from string', short=True), True),
+        (audeer.uid(from_string='from string', short=True).upper(), True),
         (None, False),
         (1234, False),
         ('', False),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -349,7 +349,7 @@ def test_is_semantic_version(version, is_semantic):
         (audeer.uid()[:-1], False),
         (audeer.uid(short=True)[:-1], False),
         ('00000000-0000-0000-0000-000000000000', True),
-        ('000000000-0000-0000-0000-00000000000', False), 
+        ('000000000-0000-0000-0000-00000000000', False),
         ('?0000000-0000-0000-0000-000000000000', False),
     ]
 )
@@ -513,7 +513,7 @@ def test_to_list(input, expected_output):
 @pytest.mark.parametrize(
     'short',
     [
-        False, 
+        False,
         True,
     ]
 )
@@ -521,13 +521,13 @@ def test_to_list(input, expected_output):
     'from_string',
     [
         None,
-        'example_string',        
+        'example_string',
     ]
 )
 def test_uid(from_string, short):
     uid = audeer.uid(from_string=from_string, short=short)
     if short:
-        assert len(uid) == 8        
+        assert len(uid) == 8
     else:
         assert len(uid) == 36
         for pos in [8, 13, 18, 23]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -339,12 +339,18 @@ def test_is_semantic_version(version, is_semantic):
     'uid, expected',
     [
         (audeer.uid(), True),
+        (audeer.uid(short=True), True),
         (audeer.uid(from_string='from string'), True),
+        (audeer.uid(from_string='from string', short=True), True),
         (None, False),
         (1234, False),
         ('', False),
         ('some random string', False),
         (audeer.uid()[:-1], False),
+        (audeer.uid(short=True)[:-1], False),
+        ('00000000-0000-0000-0000-000000000000', True),
+        ('000000000-0000-0000-0000-00000000000', False), 
+        ('?0000000-0000-0000-0000-000000000000', False),
     ]
 )
 def test_is_uid(uid, expected):
@@ -505,19 +511,29 @@ def test_to_list(input, expected_output):
 
 
 @pytest.mark.parametrize(
+    'short',
+    [
+        False, 
+        True,
+    ]
+)
+@pytest.mark.parametrize(
     'from_string',
     [
         None,
-        'example_string',
+        'example_string',        
     ]
 )
-def test_uid(from_string):
-    uid = audeer.uid(from_string=from_string)
-    assert len(uid) == 36
-    for pos in [8, 13, 18, 23]:
-        assert uid[pos] == '-'
-    uid2 = audeer.uid(from_string=from_string)
-    if from_string is not None:
-        assert uid == uid2
+def test_uid(from_string, short):
+    uid = audeer.uid(from_string=from_string, short=short)
+    if short:
+        assert len(uid) == 8        
     else:
-        assert uid != uid2
+        assert len(uid) == 36
+        for pos in [8, 13, 18, 23]:
+            assert uid[pos] == '-'
+        uid2 = audeer.uid(from_string=from_string, short=short)
+        if from_string is not None:
+            assert uid == uid2
+        else:
+            assert uid != uid2


### PR DESCRIPTION
Closes #88 

In `audb` were we used for short IDs for the first time we started to use the last 8 digits, which we also do here. The 8 digits would have been a better choice as the following example shows:

```python
for short in False, True:
    for idx in range(2):
        uid = audeer.uid(short=short)
        print(uid)
```
```
db88e120-9e2f-11ed-a57a-80fa5b66caff
db88e121-9e2f-11ed-a57a-80fa5b66caff
5b66caff
5b66caff
```

This is also the reason I had to simplify the test for short IDs.

![image](https://user-images.githubusercontent.com/10383417/215068134-434ee7b8-9710-413c-aa43-791068d42ee2.png)

![image](https://user-images.githubusercontent.com/10383417/215068178-715f724b-3f7d-4450-8289-6a949dc07897.png)
