### PR TITLE
DOC: add raises section to list_file_names()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -419,6 +419,12 @@ def list_file_names(
     Returns:
         list of path(s) to file(s)
 
+    Raises:
+        NotADirectoryError: if ``os.path.dirname(path)``
+            is not a directory
+        FileNotFoundError: if ``os.path.dirname(path)``
+            does not exists
+
     Examples:
         >>> dir_path = mkdir('path')
         >>> _ = touch(os.path.join(dir_path, 'file.wav'))

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -506,6 +506,14 @@ def test_list_file_names(tmpdir, files, path, filetype, expected,
     assert f == expected
 
 
+def test_list_file_names_errors(tmpdir):
+    with pytest.raises(NotADirectoryError):
+        file = audeer.touch(audeer.path(tmpdir, 'file'))
+        audeer.list_file_names(audeer.path(file, 'file.txt'))
+    with pytest.raises(FileNotFoundError):
+        audeer.list_file_names('not-existent/file.txt')
+
+
 def test_mkdir(tmpdir):
     # New dir
     path = str(tmpdir.mkdir('folder1'))


### PR DESCRIPTION
Closing #76 

This documents when `audeer.list_file_names()` raises an error and also adds the corresponding tests for it.

![image](https://user-images.githubusercontent.com/173624/215114993-ea9a2bb4-c326-47fc-bcf5-6fa4b0656228.png)
