### PR TITLE
DOC: add raises section to audeer.StrictVersion

### DIFF
--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -91,6 +91,10 @@ class StrictVersion(Version):
     Args:
         version: version string
 
+    Raises:
+        ValueError: if ``version`` does not match
+            the ``StrictVersion.version_re`` pattern
+
     Examples:
         >>> v1 = StrictVersion('1.17.2a1')
         >>> v1


### PR DESCRIPTION
Adds a missing raises section to the docstring of `audeer.StrictVersion`

![image](https://user-images.githubusercontent.com/173624/234610926-c85c9339-7679-4add-957f-c4945edbc0e9.png)
