### PR TITLE
Add audeer.md5()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -9,6 +9,7 @@ from audeer.core.io import (
     file_extension,
     list_dir_names,
     list_file_names,
+    md5,
     mkdir,
     move_file,
     replace_file_extension,

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1,5 +1,6 @@
 import errno
 import fnmatch
+import hashlib
 import itertools
 import os
 import platform
@@ -729,6 +730,91 @@ def mkdir(
     if path:
         os.makedirs(path, mode=mode, exist_ok=True)
     return path
+
+
+def md5(
+        path: str,
+        chunk_size: int = 8192,
+) -> str:
+    r"""Calculate MD5 checksum of file or folder.
+
+    If ``path`` is a folder,
+    the checksum is calculated
+    from all files in the folder
+    (including hidden files).
+    The checksum also encodes
+    the (relative) file names,
+    so that renaming files
+    results in a different checksum.
+    However,
+    the calculation is independent of
+    file separator of the operation systems.
+    Empty folders are ignored.
+
+    Args:
+        path: path to file or folder
+        chunk_size: chunk size in number of bytes
+
+    Returns:
+        checksum
+
+    Raises:
+        FileNotFoundError: if path does not exist
+
+    Examples:
+        >>> path = touch('file.txt')
+        >>> md5(path)
+        'd41d8cd98f00b204e9800998ecf8427e'
+        >>> path = touch('.')
+        >>> md5(path)
+        '3d8e577bddb17db339eae0b3d9bcf180'
+
+    """
+    path = safe_path(path)
+    hasher = hashlib.md5()
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(
+            errno.ENOENT,
+            os.strerror(errno.ENOENT),
+            path,
+        )
+
+    if not os.path.isdir(path):
+
+        with open(path, 'rb') as fp:
+            for chunk in md5_read_chunk(fp, chunk_size):
+                hasher.update(chunk)
+
+    else:
+
+        files = list_file_names(
+            path,
+            recursive=True,
+            hidden=True,
+            basenames=True,
+        )
+
+        for file in files:
+            # encode file name that renaming of files
+            # produces different checksum
+            hasher.update(file.replace(os.path.sep, '/').encode())
+            with open(safe_path(path, file), 'rb') as fp:
+                for chunk in md5_read_chunk(fp, chunk_size):
+                    hasher.update(chunk)
+
+    return hasher.hexdigest()
+
+
+def md5_read_chunk(
+        fp: typing.IO,
+        chunk_size: int = 8192,
+):
+    while True:
+        data = fp.read(chunk_size)
+        if not data:
+            break
+        yield data
 
 
 def move_file(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -765,8 +765,7 @@ def md5(
         >>> path = touch('file.txt')
         >>> md5(path)
         'd41d8cd98f00b204e9800998ecf8427e'
-        >>> path = touch('.')
-        >>> md5(path)
+        >>> md5('.')
         '3d8e577bddb17db339eae0b3d9bcf180'
 
     """

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -759,7 +759,7 @@ def md5(
         checksum
 
     Raises:
-        FileNotFoundError: if path does not exist
+        FileNotFoundError: if ``path`` does not exist
 
     Examples:
         >>> path = touch('file.txt')

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -29,6 +29,7 @@ audeer
     list_dir_names
     list_file_names
     LooseVersion
+    md5
     mkdir
     move_file
     path

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -964,9 +964,10 @@ def test_md5_errors():
     with pytest.raises(FileNotFoundError):
         audeer.md5('does/not/exist')
 
+
 @pytest.mark.parametrize(
     'file, content, expected',
-    [   
+    [
         (  # empty file
             'file.txt',
             None,
@@ -977,7 +978,7 @@ def test_md5_errors():
             'hello world',
             '5eb63bbbe01eeed093cb22bb8f5acdc3',
         ),
-        ( 
+        (
             'file.txt',
             'Hello World',
             'b10a8db164e0754105b7a99be72e3fe5',
@@ -1001,7 +1002,7 @@ def test_md5_file(tmpdir, file, content, expected):
 
 @pytest.mark.parametrize(
     'tree, content, expected',
-    [   
+    [
         (  # empty folder
             [],
             None,


### PR DESCRIPTION
Implements functions to calculate MD5 checksum for a file or a whole folder:

![image](https://user-images.githubusercontent.com/10383417/235175381-74c1c4df-bbf9-4098-b092-a56120c289b2.png)

The function can then be used by `audb` and `audbackend`, which currently implement their own functions.
