### PR TITLE
TST: exclude Windows only code from coverage

### DIFF
--- a/.coveragerc.Linux
+++ b/.coveragerc.Linux
@@ -2,4 +2,3 @@
 exclude_lines =
     pragma: no cover
     pragma: no Linux cover
-    pragma: no Linux or macOS cover

--- a/.coveragerc.Linux
+++ b/.coveragerc.Linux
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    pragma: no Linux cover

--- a/.coveragerc.Windows
+++ b/.coveragerc.Windows
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    pragma: no Windows cover

--- a/.coveragerc.macOS
+++ b/.coveragerc.macOS
@@ -2,4 +2,3 @@
 exclude_lines =
     pragma: no cover
     pragma: no macOS cover
-    pragma: no Linux or macOS cover

--- a/.coveragerc.macOS
+++ b/.coveragerc.macOS
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    pragma: no macOS cover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        python -m pytest --cov-config=.coveragerc.${{ runner.os }}
+        python -m pytest
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -372,7 +372,7 @@ def extract_archive(
     if not keep_archive:
         os.remove(archive)
 
-    if os.name == 'nt':  # pragma: no Linux or macOS cover
+    if os.name == 'nt':  # pragma: no cover
         # replace '/' with '\' on Windows
         files = [file.replace('/', os.path.sep) for file in files]
 


### PR DESCRIPTION
Closes #107 

Exclude Windows only code from coverage to be able to reach full coverage when just running
```bash
$ python -m pytest
```