### PR TITLE
DOC: add missing 1.20.0 changelog entry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -53,6 +53,10 @@ Version 1.20.0 (2023-05-02)
   now returns the original filename
   when an empty new file extension is provided
   instead of adding ``'.'`` at the end of the filename
+* Fixed: ``audeer.extract_archive()``
+  and ``audeer.extract_archives()``
+  no return normalized relative paths
+  under Windows
 * Fixed: add raises section
   to API documentation of ``audeer.list_file_names()``
 * Fixed: add raises section

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,7 +55,7 @@ Version 1.20.0 (2023-05-02)
   instead of adding ``'.'`` at the end of the filename
 * Fixed: ``audeer.extract_archive()``
   and ``audeer.extract_archives()``
-  no return normalized relative paths
+  now return normalized relative paths
   under Windows
 * Fixed: add raises section
   to API documentation of ``audeer.list_file_names()``

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -56,7 +56,7 @@ Version 1.20.0 (2023-05-02)
 * Fixed: ``audeer.extract_archive()``
   and ``audeer.extract_archives()``
   now return normalized relative paths
-  under Windows
+  also under Windows
 * Fixed: add raises section
   to API documentation of ``audeer.list_file_names()``
 * Fixed: add raises section


### PR DESCRIPTION
Closes #109 

This adds a missing changelog entry for the 1.20.0 release, mentioning that return values of `audeer.extract_archive()` and `audeer.extract_archives()` have changed to normalized paths.

![image](https://user-images.githubusercontent.com/173624/235948761-70c7ebc4-cd9a-4207-9e9a-bf5a66a2bf5b.png)

/cc @Bahaabrougui 