### PR TITLE
CI: update publish Action to new pyproject.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,14 +19,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine virtualenv
     # PyPI package
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         python -m twine upload dist/*
     # Docuemntation
     - name: Install doc dependencies


### PR DESCRIPTION
We updated to use pyproject.toml in https://github.com/audeering/audeer/pull/114, but forgot to update the publish Action accordingly.