### PR TITLE
CI: update publish Action to use new env variables

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
         CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
         CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
-        echo "::set-output name=body::$CHANGELOG"
+        run echo "body=$CHANGELOG" >> $GITHUB_OUTPUT
     - name: Create release on Github
       id: create_release
       uses: softprops/action-gh-release@v1


### PR DESCRIPTION
The set-output is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

We are now using the new environment variable as shown in https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter