### PR TITLE
CI: fix publishing to PyPI with 2FA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,13 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+
     steps:
     - uses: actions/checkout@v3
       with:
@@ -19,15 +26,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine virtualenv
+        pip install build virtualenv
     # PyPI package
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        python -m twine upload dist/*
+    - name: Build Python package
+      run: python -m build
+    - name: Publish Python package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
     # Docuemntation
     - name: Install doc dependencies
       run: |


### PR DESCRIPTION
As we have now 2FA enabled on PyPI we need to change the way the package is published.
See https://blog.pypi.org/posts/2023-05-25-securing-pypi-with-2fa/