### PR TITLE
Support *paths in mkdir() and rmdir()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -499,7 +499,7 @@ def list_dir_names(
         FileNotFoundError: if path does not exists
 
     Examples:
-        >>> _ = mkdir('path/a/.b/c')
+        >>> _ = mkdir('path', 'a', '.b', 'c')
         >>> list_dir_names(
         ...     'path',
         ...     basenames=True,
@@ -579,7 +579,7 @@ def list_file_names(
         >>> _ = touch(os.path.join(dir_path, 'file.wav'))
         >>> _ = touch(os.path.join(dir_path, 'File.wav'))
         >>> _ = touch(os.path.join(dir_path, '.lock'))
-        >>> sub_dir_path = mkdir(os.path.join('path', 'sub'))
+        >>> sub_dir_path = mkdir('path', 'sub')
         >>> _ = touch(os.path.join(sub_dir_path, 'file.ogg'))
         >>> _ = touch(os.path.join(sub_dir_path, '.lock'))
         >>> list_file_names(
@@ -714,7 +714,7 @@ def list_file_names(
 
 def mkdir(
         path: typing.Union[str, bytes],
-        *,
+        *paths: typing.Sequence[typing.Union[str, bytes]],
         mode: int = 0o777
 ) -> str:
     """Create directory.
@@ -738,18 +738,21 @@ def mkdir(
 
     Args:
         path: absolute or relative path of directory to create
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
         mode: set permissions of created folders
 
     Returns:
         absolute path to the created directory
 
     Examples:
-        >>> p = mkdir('path1/path2/path3')
+        >>> p = mkdir('path1', 'path2', 'path3')
         >>> os.path.basename(p)
         'path3'
 
     """
-    path = safe_path(path)
+    path = safe_path(path, *paths)
     if path:
         os.makedirs(path, mode=mode, exist_ok=True)
     return path
@@ -934,6 +937,7 @@ def replace_file_extension(
 
 def rmdir(
         path: typing.Union[str, bytes],
+        *paths: typing.Sequence[typing.Union[str, bytes]],
 ):
     """Remove directory.
 
@@ -943,20 +947,23 @@ def rmdir(
 
     Args:
         path: absolute or relative path of directory to remove
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
 
     Raises:
         NotADirectoryError: if path is not a directory
 
     Examples:
-        >>> _ = mkdir('path1/path2/path3')
+        >>> _ = mkdir('path1', 'path2', 'path3')
         >>> list_dir_names('path1', basenames=True)
         ['path2']
-        >>> rmdir('path1/path2')
+        >>> rmdir('path1', 'path2')
         >>> list_dir_names('path1')
         []
 
     """
-    path = safe_path(path)
+    path = safe_path(path, *paths)
     if os.path.exists(path):
         shutil.rmtree(path)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1093,7 +1093,7 @@ def test_mkdir(tmpdir):
     assert p == os.path.join(path, 'folder4')
     # Subdirectories
     os.chdir(path)
-    p = audeer.mkdir('folder5/folder6')
+    p = audeer.mkdir('folder5', 'folder6')
     os.chdir(current_path)
     assert os.path.isdir(p) is True
     assert p == os.path.join(path, 'folder5', 'folder6')
@@ -1109,27 +1109,24 @@ def test_mkdir(tmpdir):
     assert p == path
     # Mode, see https://stackoverflow.com/a/705088
     # Default mode
-    path = os.path.join(str(tmpdir.mkdir('folder8')), 'sub-folder')
     os.umask(0)
-    p = audeer.mkdir(path)
+    p = audeer.mkdir(tmpdir, 'folder8', 'sub-folder')
     mode = stat.S_IMODE(os.stat(p).st_mode)
     expected_mode = int('777', 8)
     assert mode == expected_mode
     # Non-default modes
     # Under Windows, changing permissions does not work,
     # there we always expect 777
-    path = os.path.join(str(tmpdir.mkdir('folder9')), 'sub-folder')
     os.umask(0)
-    p = audeer.mkdir(path, mode=0o775)
+    p = audeer.mkdir(tmpdir, 'folder9', 'sub-folder', mode=0o775)
     expected_mode = '775'
     if platform.system() == 'Windows':
         expected_mode = '777'
     mode = stat.S_IMODE(os.stat(p).st_mode)
     assert mode == int(expected_mode, 8)
     assert mode != int('755', 8)
-    path = os.path.join(str(tmpdir.mkdir('folder10')), 'sub-folder')
     os.umask(0)
-    p = audeer.mkdir(path, mode=0o755)
+    p = audeer.mkdir(tmpdir, 'folder10', 'sub-folder', mode=0o755)
     expected_mode = '755'
     if platform.system() == 'Windows':
         expected_mode = '777'
@@ -1208,9 +1205,8 @@ def test_rmdir(tmpdir):
     audeer.rmdir(p)
     assert not os.path.exists(p)
     # Folder with folder content
-    path = str(tmpdir.mkdir('folder'))
-    p = audeer.mkdir(os.path.join(path, 'sub-folder'))
-    audeer.rmdir(os.path.dirname(p))
+    p = audeer.mkdir(tmpdir, 'folder', 'sub-folder')
+    audeer.rmdir(tmpdir, 'folder')
     assert not os.path.exists(p)
     assert not os.path.exists(os.path.dirname(p))
     # Relative path


### PR DESCRIPTION
Closes #64 

This extends `audeer.mkdir()` and `audeer.rmdir()` to support several path arguments, so we can replace
```python
audeer.mkdir(audeer.path('a', 'b'))
audeer.rmdir(audeer.path('a', 'b'))
```
with
```python
audeer.mkdir('a', 'b')
audeer.rmdir('a', 'b')
```

I realized that I'm typing very often `audeer.mkdir(audeer.path(...))` in my daily coding,
so the above changes would make it easier.
The downside is that `audeer.rmdir('a', 'b')` might be ambiguous for a user to grasp what it is doing, e.g. deleting `a/b`, or deleting `a` and `b`. 
@audeerington any opinion if we should change it or not?

---

![image](https://github.com/audeering/audeer/assets/173624/0681012d-f5b5-4ff0-ad4f-37a15d21d8de)

---

![image](https://github.com/audeering/audeer/assets/173624/9aa504a7-31b7-4e4d-9978-a6e405ea1bf6)
