### PR TITLE
Support *paths in touch()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -576,12 +576,12 @@ def list_file_names(
 
     Examples:
         >>> dir_path = mkdir('path')
-        >>> _ = touch(os.path.join(dir_path, 'file.wav'))
-        >>> _ = touch(os.path.join(dir_path, 'File.wav'))
-        >>> _ = touch(os.path.join(dir_path, '.lock'))
+        >>> _ = touch(dir_path, 'file.wav')
+        >>> _ = touch(dir_path, 'File.wav')
+        >>> _ = touch(dir_path, '.lock')
         >>> sub_dir_path = mkdir('path', 'sub')
-        >>> _ = touch(os.path.join(sub_dir_path, 'file.ogg'))
-        >>> _ = touch(os.path.join(sub_dir_path, '.lock'))
+        >>> _ = touch(sub_dir_path, 'file.ogg')
+        >>> _ = touch(sub_dir_path, '.lock')
         >>> list_file_names(
         ...     dir_path,
         ...     basenames=True,

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -860,7 +860,7 @@ def move_file(
 
     Examples:
         >>> path = mkdir('folder')
-        >>> src_path = touch(os.path.join(path, 'file1'))
+        >>> src_path = touch(path, 'file1')
         >>> dst_path = os.path.join(path, 'file2')
         >>> move_file(src_path, dst_path)
         >>> list_file_names(path, basenames=True)

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -969,7 +969,8 @@ def rmdir(
 
 
 def touch(
-        path: typing.Union[str, bytes]
+        path: typing.Union[str, bytes],
+        *paths: typing.Sequence[typing.Union[str, bytes]],
 ) -> str:
     """Create an empty file.
 
@@ -979,6 +980,9 @@ def touch(
 
     Args:
         path: path to file
+        *paths: additional arguments
+            to be joined with ``path``
+            by :func:`os.path.join`
 
     Returns:
         expanded path to file
@@ -989,7 +993,7 @@ def touch(
         'file.txt'
 
     """
-    path = safe_path(path)
+    path = safe_path(path, *paths)
     if os.path.exists(path):
         os.utime(path, None)
     else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -505,7 +505,7 @@ def test_list_dir_names(tmpdir, dir_list, expected, recursive, hidden):
 
 def test_list_dir_names_errors(tmpdir):
     with pytest.raises(NotADirectoryError):
-        file = audeer.touch(audeer.path(tmpdir, 'file.txt'))
+        file = audeer.touch(tmpdir, 'file.txt')
         audeer.list_dir_names(file)
     with pytest.raises(FileNotFoundError):
         audeer.list_dir_names('not-existent')
@@ -1153,7 +1153,7 @@ def test_move_file(tmpdir, src_file, dst_file):
     tmp_path = str(tmpdir.mkdir('folder'))
     tmp_path = audeer.mkdir(tmp_path)
 
-    src_path = audeer.touch(os.path.join(tmp_path, src_file))
+    src_path = audeer.touch(tmp_path, src_file)
     dst_path = os.path.join(tmp_path, dst_file)
 
     audeer.move_file(src_path, dst_path)
@@ -1220,8 +1220,7 @@ def test_rmdir(tmpdir):
 
 
 def test_touch(tmpdir):
-    path = str(tmpdir.mkdir('folder1'))
-    path = audeer.mkdir(path)
+    path = audeer.mkdir(tmpdir, 'folder1')
     path = os.path.join(path, 'file')
     assert not os.path.exists(path)
     audeer.touch(path)


### PR DESCRIPTION
Similar to https://github.com/audeering/audeer/pull/126 this adds support for `*paths` to `audeer.touch()`.
This allows a syntax like `audeer.touch('folder', 'file.txt')`.

We have a few more functions that have `path` as input, but we cannot add support for `*paths` to all of them, e.g. `move_file()` requires `src_path` and `dst_path`. Besides `audeer.touch()`, we might consider to add it to `audeer.list_file_names()` and `audeer.list_dir_names()`, but I'm not completely convinced ;)

![image](https://github.com/audeering/audeer/assets/173624/6fbfd65d-14f0-4b69-b0de-42ce8eb7e7b5)
