### PR TITLE
Add audeer.move()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -10,6 +10,7 @@ from audeer.core.io import list_dir_names
 from audeer.core.io import list_file_names
 from audeer.core.io import md5
 from audeer.core.io import mkdir
+from audeer.core.io import move
 from audeer.core.io import move_file
 from audeer.core.io import replace_file_extension
 from audeer.core.io import rmdir

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -859,6 +859,7 @@ def move(
         dst_path: destination file path
 
     Raises:
+        OSError: if the destination is a non-empty folder
         PermissionError: if a folder should be moved
             to an already existing folder
             under Windows

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -842,6 +842,39 @@ def md5_read_chunk(
         yield data
 
 
+def move(
+        src_path,
+        dst_path,
+):
+    """Move a file or folder independent of operating system.
+
+    As :func:`os.rename` works differently
+    under Unix and Windows
+    and :func:`shutil.move` can be slow,
+    we use :func:`os.replace`
+    to move the file.
+
+    Args:
+        src_path: source file path
+        dst_path: destination file path
+
+    Raises:
+        PermissionError: if a folder should be moved
+            to an already existing folder
+            under Windows
+
+    Examples:
+        >>> path = mkdir('folder')
+        >>> src_path = touch(os.path.join(path, 'file1'))
+        >>> dst_path = os.path.join(path, 'file2')
+        >>> move(src_path, dst_path)
+        >>> list_file_names(path, basenames=True)
+        ['file2']
+
+    """
+    os.replace(src_path, dst_path)
+
+
 def move_file(
         src_path,
         dst_path,
@@ -867,7 +900,7 @@ def move_file(
         ['file2']
 
     """
-    os.replace(src_path, dst_path)
+    move(src_path, dst_path)
 
 
 def replace_file_extension(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -852,11 +852,11 @@ def move(
     under Unix and Windows
     and :func:`shutil.move` can be slow,
     we use :func:`os.replace`
-    to move the file.
+    to move the file/folder.
 
     Args:
-        src_path: source file path
-        dst_path: destination file path
+        src_path: source file/folder path
+        dst_path: destination file/folder path
 
     Raises:
         OSError: if the destination is a non-empty folder
@@ -887,6 +887,10 @@ def move_file(
     and :func:`shutil.move` can be slow,
     we use :func:`os.replace`
     to move the file.
+
+    Warning:
+        :func:`audeer.move_file` is deprecated,
+        please use :func:`audeer.move` instead.
 
     Args:
         src_path: source file path

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -31,6 +31,7 @@ audeer
     LooseVersion
     md5
     mkdir
+    move
     move_file
     path
     progress_bar

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1148,6 +1148,34 @@ def test_mkdir(tmpdir):
         ),
     ]
 )
+def test_move(tmpdir, src_file, dst_file):
+
+    tmp_path = str(tmpdir.mkdir('folder'))
+    tmp_path = audeer.mkdir(tmpdir, 'folder')
+
+    src_path = audeer.touch(os.path.join(tmp_path, src_file))
+    dst_path = os.path.join(tmp_path, dst_file)
+
+    audeer.move_file(src_path, dst_path)
+
+    if src_file != dst_file:
+        assert not os.path.exists(src_path)
+    assert os.path.exists(dst_path)
+
+
+@pytest.mark.parametrize(
+    'src_file, dst_file',
+    [
+        (
+            'file1',
+            'file1',
+        ),
+        (
+            'file1',
+            'file2',
+        ),
+    ]
+)
 def test_move_file(tmpdir, src_file, dst_file):
 
     tmp_path = str(tmpdir.mkdir('folder'))


### PR DESCRIPTION
Closes #98 
Closes #96 

Add `audeer.move()` as a replacement for `audeer.move_file()`.
We realized that `audeer.move_file()` does also support moving folders.
So it makes sense to update its docstring accordingly and also reflect it in the name.
As backward compatibility is a very important aspect of `audeer`, we do not remove `audeer.move_file()`, but just add a statement that in the docs that `audeer.move()` should be used.

![image](https://github.com/audeering/audeer/assets/173624/8127af3d-1467-44d2-9945-d910265ef049)

![image](https://github.com/audeering/audeer/assets/173624/3731533d-0d31-490d-a6c9-9bf951eaaa49)
