### PR TITLE
Add follow_symlink argument to audeer.path()

### DIFF
--- a/audeer/core/conftest.py
+++ b/audeer/core/conftest.py
@@ -1,8 +1,12 @@
 import pytest
 
+import audeer
+
 
 @pytest.fixture(autouse=True)
-def docdir(request):
+def docdir(doctest_namespace, request):
+    # make sure audeer is imported
+    doctest_namespace['audeer'] = audeer
     # set temporal working directory in docstring examples
     tmpdir = request.getfixturevalue('tmpdir')
     with tmpdir.as_cwd():

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -85,6 +85,7 @@ _path = path
 def safe_path(
         path: typing.Union[str, bytes],
         *paths: typing.Sequence[typing.Union[str, bytes]],
+        follow_symlink: bool = True,
 ) -> str:
     """Expand and normalize to absolute path.
 
@@ -94,6 +95,9 @@ def safe_path(
     without ``..`` or ``~``,
     and independent of the path separator
     of the operating system.
+    If ``follow_symlink`` is ``False``,
+    the faster :func:`os.path.abspath` is used
+    instead of :func:`os.path.realpath`.
 
     Warning:
         :func:`audeer.safe_path` is deprecated,
@@ -104,6 +108,10 @@ def safe_path(
         *paths: additional arguments
             to be joined with ``path``
             by :func:`os.path.join`
+        follow_symlink: if ``True``
+            symlinks are followed
+            and the path of the original file
+            is returned
 
     Returns:
         (joined and) expanded path
@@ -116,6 +124,15 @@ def safe_path(
         >>> file = safe_path('~/path/.././path', './file.txt')
         >>> file[len(home) + 1:]
         'path/file.txt'
+        >>> file = audeer.touch('file.txt')
+        >>> link = path('link.txt')
+        >>> os.symlink(file, link)
+        >>> file = path(link)
+        >>> os.path.basename(file)
+        'file.txt'
+        >>> file = path(link, follow_symlink=False)
+        >>> os.path.basename(file)
+        'link.txt'
 
     """
     return _path(path, *paths)

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -60,8 +60,12 @@ def test_path_symlinks(tmpdir):
     file = os.path.join(folder, filename)
     link = os.path.join(folder, linkname)
     os.symlink(file, link)
-    expected_path = os.path.realpath(os.path.expanduser(link))
-    path = audeer.path(link)
+    for follow_symlink in [True, False]:
+        if follow_symlink:
+            expected_path = os.path.realpath(os.path.expanduser(link))
+        else:
+            expected_path = os.path.abspath(os.path.expanduser(link))
+        path = audeer.path(link, follow_symlink=follow_symlink)
     _, path = os.path.splitdrive(path)
     _, expected_path = os.path.splitdrive(expected_path)
     assert path == expected_path


### PR DESCRIPTION
Closes #131 

This adds the `follow_symlink` argument to `audeer.path()` (~~but not to `audeer.safe_path()`~~), which can be used to speed up it's processing when it is not important to convert symbolic links to the actual file paths.

Execution time when running on 1,000,000 files.

| `follow_symlink=True` | `follow_symlink=False` |
| --- | --- |
| 12.03 s | 2.22 s |

<details><summary>Benchmark code</summary>

```python
import tempfile
import time

import audeer


repetitions = 1000000

with tempfile.TemporaryDirectory() as tmpdir:
    files = [ 
        audeer.touch(audeer.path(tmpdir, 'benchmark-{n}.txt'))
        for n in range(repetitions)
    ]   

    for follow_symlink in [True, False]:
        t = time.time()
        for file in files:
            audeer.path(file, follow_symlink=follow_symlink)
        print(f'{time.time() - t:.2f} s')
```

</details>

![image](https://github.com/audeering/audeer/assets/173624/a64a5fd2-c013-4a96-82eb-ffc65d1f5627)
