### PR TITLE
Do now follow symlinks in download_url()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -256,7 +256,7 @@ def download_url(
         'favicon.png'
 
     """  # noqa: E501
-    destination = safe_path(destination)
+    destination = safe_path(destination, follow_symlink=False)
     if os.path.isdir(destination):
         destination = os.path.join(destination, os.path.basename(url))
     if os.path.exists(destination) and not force_download:


### PR DESCRIPTION
Based on https://github.com/audeering/audeer/pull/132 this changes `audeer.download_url()` to call `audeer.path(..., follow_symlink=False)` to make it faster when used in a loop. It does not have an effect on its behavior, but introduces a breaking change as it now returns a symlink and not the realpath if `destination` was given as a symlink.