### PR TITLE
Don't convert symlinks in audeer.extract_archive()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -314,6 +314,9 @@ def extract_archive(
         ['a.txt']
 
     """
+    archive = safe_path(archive, follow_symlink=False)
+    destination = safe_path(destination, follow_symlink=False)
+
     if not os.path.exists(archive):
         raise FileNotFoundError(
             errno.ENOENT,

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -314,9 +314,6 @@ def extract_archive(
         ['a.txt']
 
     """
-    archive = safe_path(archive)
-    destination = safe_path(destination)
-
     if not os.path.exists(archive):
         raise FileNotFoundError(
             errno.ENOENT,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -32,7 +32,7 @@ def tree(tmpdir, request):
 
 
 @pytest.mark.parametrize(
-    "tree, root, files, archive_create, archive_extract, destination, " "expected",
+    "tree, root, files, archive_create, archive_extract, destination, expected",
     [
         (  # empty
             [],
@@ -338,6 +338,19 @@ def test_archives(
         keep_archive=False,
     )
     assert not os.path.exists(archive_extract)
+
+
+def test_archives_symlink(tmpdir):
+    # Create folder with files and symlink to folder
+    folder = audeer.mkdir(tmpdir, "folder")
+    file = audeer.touch(folder, "file.txt")
+    link = os.path.join(tmpdir, "link")
+    os.symlink(folder, link)
+    archive = os.path.join(tmpdir, "archive.zip")
+
+    audeer.create_archive(link, [file], archive)
+    result = audeer.extract_archive(archive, link)
+    assert result == ["file.txt"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Speeds up `audeer.extract_archive()` by using `audeer.path(..., follow_symlink=False)`.