### PR TITLE
Not follow symlinks in Ensure basename_wo_ext()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -48,7 +48,7 @@ def basename_wo_ext(
         'file'
 
     """
-    path = safe_path(path)
+    path = safe_path(path, follow_symlink=False)  # convert byte to str
     path = os.path.basename(path)
     if ext is not None:
         if not ext.startswith("."):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -360,6 +360,15 @@ def test_basename_wo_ext(path, ext, basename):
     assert isinstance(b, str)
 
 
+def test_basename_wo_ext_symlink(tmpdir):
+    # Ensure basename_wo_ext() is not influenced by existing files
+    file = audeer.touch(tmpdir, "file.txt")
+    link = os.path.join(tmpdir, "link.txt")
+    os.symlink(file, link)
+    assert audeer.basename_wo_ext(file) == "file"
+    assert audeer.basename_wo_ext(link) == "link"
+
+
 @pytest.mark.parametrize(
     "dirs,expected",
     [


### PR DESCRIPTION
Relates to #136 

The result of `audeer.basename_wo_ext()` should not be influenced by existing files or symlinks.

This adds first a failing test for the current behavior and then a fix, that avoids following symlinks. 