### PR TITLE
Add follow_symlink argument to rmdir()

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -970,7 +970,7 @@ def replace_file_extension(
 def rmdir(
     path: typing.Union[str, bytes],
     *paths: typing.Sequence[typing.Union[str, bytes]],
-    follow_symlink=True,
+    follow_symlink: bool = True,
 ):
     """Remove directory.
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -970,6 +970,7 @@ def replace_file_extension(
 def rmdir(
     path: typing.Union[str, bytes],
     *paths: typing.Sequence[typing.Union[str, bytes]],
+    follow_symlink=True,
 ):
     """Remove directory.
 
@@ -982,9 +983,15 @@ def rmdir(
         *paths: additional arguments
             to be joined with ``path``
             by :func:`os.path.join`
+        follow_symlink: if ``True``
+            and path is a symbolic link,
+            the link and the folder it points to
+            will be removed
 
     Raises:
         NotADirectoryError: if path is not a directory
+        OSError: if ``follow_symlink`` is ``False``
+            and ``path`` is a symbolic link
 
     Examples:
         >>> _ = mkdir("path1", "path2", "path3")
@@ -995,7 +1002,7 @@ def rmdir(
         []
 
     """
-    path = safe_path(path, *paths)
+    path = safe_path(path, *paths, follow_symlink=follow_symlink)
     if os.path.exists(path):
         shutil.rmtree(path)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1466,6 +1466,17 @@ def test_rmdir(tmpdir):
     audeer.rmdir("folder")
     assert not os.path.exists(path)
     os.chdir(current_path)
+    # Symbolic link
+    path = audeer.mkdir(tmpdir, "folder")
+    link = os.path.join(tmpdir, "link")
+    os.symlink(path, link)
+    with pytest.raises(OSError, match="symbolic link"):
+        audeer.rmdir(link, follow_symlink=False)
+    assert os.path.exists(link)
+    assert os.path.exists(path)
+    audeer.rmdir(link, follow_symlink=True)
+    assert not os.path.exists(link)
+    assert not os.path.exists(path)
 
 
 def test_touch(tmpdir):


### PR DESCRIPTION
This adds the `follow_symlink` argument to `audeer.rmdir()`, but sets it to `True` as default as this is avoids breaking changes and seems to be a meaningful behavior.
I decided against silently setting it to `True` internally as we still use `audeer.rmdir()` in loops that can get a speed up by ensuring that we don't have a symbolic link before we call `audeer.rmdir()`, e.g. https://github.com/audeering/audb/blob/12ad8520e45c11f152c5c96b11f221e3a1fb40f2/audb/core/load_to.py#L303-L329

I also added tests and included a new error under Raises section in the docstring that can happen with `follow_symlink=False`.

![image](https://github.com/audeering/audeer/assets/173624/4340b4eb-f7a1-401a-b283-eaab4e9f3c80)


