### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,46 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 2.0.0 (2024-01-XX)
+--------------------------
+
+* Added: ``follow_symlink`` keyword argument
+  to ``audeer.path()``
+  with default value ``False``
+* Added: ``follow_symlink`` keyword argument
+  to ``audeer.rmdir()``
+  with default value ``True``
+* Changed: ``audeer.path()`` does no longer
+  uses ``os.path.realpath()``,
+  but ``os.path.abspath()``.
+  This means it does no longer convert symlinks
+  to the real path,
+  but returns the path to the symlink.
+  This provides a speed up of ``audeer.path()``
+  up to 6x
+  as it no longer requires a disk operation.
+  The old behavior of ``audeer.path()``
+  can be achieved by calling
+  ``audeer.path(..., follow_symlink=True)``.
+  The output of the following functions
+  is also affected by this change
+  if a symlink is part of their input path:
+  ``audeer.common_directory()``,
+  ``audeer.download_url()``,
+  ``audeer.list_dir_names()``,
+  ``audeer.list_file_names()``,
+  ``audeer.mkdir()``,
+  ``audeer.touch()``
+* Changed: ``audeer.create_archive()``
+  can no longer include symbolic links
+  that are located outside of ``root``
+* Fixed: ``audeer.basename_wo_ext()``,
+  ``audeer.file_extension()``,
+  and ``audeer.replace_file_extension()``
+  are no longer affected by existing files,
+  but rely only on the provided input string
+
+
 Version 1.21.0 (2023-12-06)
 ---------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
-Version 2.0.0 (2024-01-XX)
+Version 2.0.0 (2024-01-25)
 --------------------------
 
 * Added: ``follow_symlink`` keyword argument

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,13 +37,13 @@ Version 2.0.0 (2024-01-25)
   ``audeer.list_file_names()``,
   ``audeer.mkdir()``,
   ``audeer.touch()``
-* Changed: ``audeer.create_archive()``
+* Changed: the ``files`` argument of ``audeer.create_archive()``
   can no longer include symbolic links
   that are located outside of ``root``
 * Fixed: ``audeer.basename_wo_ext()``,
   ``audeer.file_extension()``,
   and ``audeer.replace_file_extension()``
-  are no longer affected by existing files,
+  are no longer affected by existing files and symlinks,
   but rely only on the provided input string
 
 


### PR DESCRIPTION
I decided for a new major release of `audeer` as we have breaking changes for a lot of its functions. Fortunately, the consequences shouldn't be too bad.

I checked our main three packages and created pull requests with the needed adaptations:
* [audformat](https://github.com/audeering/audformat/pull/411)
* [audb](https://github.com/audeering/audb/pull/348)
* [audinterface](https://github.com/audeering/audinterface/pull/153), no changes needed

![image](https://github.com/audeering/audeer/assets/173624/040d967b-ec6f-47d9-9cce-dbc0f8c94406)

