### PR TITLE
Add maximum_refresh_time to progress_bar()

### DIFF
--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -49,7 +49,7 @@ def progress_bar(
     total: int = None,
     desc: str = None,
     disable: bool = False,
-    maximum_refresh_time: typing.Optional = 1,
+    maximum_refresh_time: float = None,
 ) -> tqdm:
     r"""Progress bar with optional text on the right.
 
@@ -107,10 +107,32 @@ def progress_bar(
     )
 
 
-def tqdm_wrapper(iterable, maximum_refresh_time, *args, **kwargs):
-    r"""Progress bar wrapper to enforce update once a second.
+def tqdm_wrapper(
+    iterable: typing.Sequence,
+    maximum_refresh_time: float,
+    *args,
+    **kwargs,
+) -> tqdm:
+    r"""Tqdm progress bar wrapper to enforce update once a second.
 
-    See https://github.com/tqdm/tqdm/issues/861#issuecomment-2197893883.
+    When using tqdm with large time durations
+    between single steps of the iteration,
+    it will not automatically update the elapsed time,
+    but needs to be forced,
+    see https://github.com/tqdm/tqdm/issues/861#issuecomment-2197893883.
+
+    Args:
+        iterable: sequence to iterate through
+        maximum_refresh_time: refresh the progress bar
+            at least every ``maximum_refresh_time`` seconds,
+            using another thread.
+            If ``None``,
+            no refreshing is enforced
+        args: arguments passed on to ``tqdm``
+        kwargs: keyword arguments passed on to ``tqdm``
+
+    Returns:
+        progress bar object
 
     """
     pbar = tqdm(iterable, *args, **kwargs)

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -37,3 +37,15 @@ def test_progress_bar():
     pbar = audeer.progress_bar([0.1])
     for step in pbar:
         time.sleep(step)
+
+
+def test_progress_bar_update():
+    r"""Ensure progress bar is refreshed.
+
+    If the progress bar has to wait for a long time
+    until it would get updated,
+    we enforce an update by a given time.
+
+    """
+    for _ in audeer.progress_bar(range(2), maximum_refresh_time=0.01):
+        time.sleep(0.05)


### PR DESCRIPTION
This adds `maximum_refresh_time` which allows to ensure that a progress bar is refreshed at least every `maximum_refresh_time` seconds.

This is of interest when the time between the single steps of the progress bar iteration take very long, and a user might start to wonder if the process is stalled or still running.

The refreshing is achieved by using another thread as proposed in https://github.com/tqdm/tqdm/issues/861#issuecomment-2197893883. To not change and possible break any existing code, the default value of `maximum_refresh_time` is `None` which will not force refreshing the progress bar. I would propose we set this value then to an actual value in applications where it is relevant, e.g. `audb`.

For a local example run:

```python
import time

import audeer


for _ in audeer.progress_bar(range(2)):  # old behavior
    time.sleep(4)
```

which results in a display of `00:00` for a long time:

![image](https://github.com/audeering/audeer/assets/173624/45e9b1c1-907b-45f5-b76f-312817b3a922)

and compare with
```python
for _ in audeer.progress_bar(range(2), maximum_refresh_time=1):
    time.sleep(2)
```

which updates the already past time every second:

![image](https://github.com/audeering/audeer/assets/173624/62374225-3ac2-47c2-a8fc-9a28c5dc71a9)

Updated docstring:

![image](https://github.com/audeering/audeer/assets/173624/67388e64-890a-4ba4-8f72-18712d74f3c8)

