### PR TITLE
TST: fix symlink removal error message

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1525,8 +1525,12 @@ def test_rmdir(tmpdir):
     # Error message is broken
     # for newer version of Python 3.12
     # under MacOS and Linux
-    print(f"{sys.version_info=}")
-    if sys.version_info == (3, 12, 4) and platform.system() != "Windows":
+    python_version = (
+        sys.version_info.major,
+        sys.version_info.minor,
+        sys.version_info.micro,
+    )
+    if python_version == (3, 12, 4) and platform.system() != "Windows":
         error_msg = "None"
     else:
         error_msg = "symbolic link"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1522,6 +1522,7 @@ def test_rmdir(tmpdir):
     link = os.path.join(tmpdir, "link")
     os.symlink(path, link)
     with pytest.raises(OSError, match="symbolic link"):
+        # Skip this on MacOS Python 3.12?
         audeer.rmdir(link, follow_symlink=False)
     assert os.path.exists(link)
     assert os.path.exists(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1523,7 +1523,7 @@ def test_rmdir(tmpdir):
     link = os.path.join(tmpdir, "link")
     os.symlink(path, link)
     # Error message changed at some point for Python 3.12
-    if sys.version_info >= "3.12.1":
+    if sys.version_info >= (3, 12, 1):
         error_msg = "None"
     else:
         error_msg = "symbolic link"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1522,8 +1522,10 @@ def test_rmdir(tmpdir):
     path = audeer.mkdir(tmpdir, "folder")
     link = os.path.join(tmpdir, "link")
     os.symlink(path, link)
-    # Error message changed at some point for Python 3.12
-    if sys.version_info >= (3, 12, 1):
+    # Error message is broken
+    # for newer version of Python 3.12
+    # under MacOS and Linux
+    if sys.version_info >= (3, 12, 1) and platform.system() != "Windows":
         error_msg = "None"
     else:
         error_msg = "symbolic link"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1525,7 +1525,7 @@ def test_rmdir(tmpdir):
     # Error message is broken
     # for newer version of Python 3.12
     # under MacOS and Linux
-    if sys.version_info >= (3, 12, 1) and platform.system() != "Windows":
+    if sys.version_info == (3, 12, 4) and platform.system() != "Windows":
         error_msg = "None"
     else:
         error_msg = "symbolic link"

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1525,6 +1525,7 @@ def test_rmdir(tmpdir):
     # Error message is broken
     # for newer version of Python 3.12
     # under MacOS and Linux
+    print(f"{sys.version_info=}")
     if sys.version_info == (3, 12, 4) and platform.system() != "Windows":
         error_msg = "None"
     else:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import stat
+import sys
 import time
 
 import pytest
@@ -1521,8 +1522,12 @@ def test_rmdir(tmpdir):
     path = audeer.mkdir(tmpdir, "folder")
     link = os.path.join(tmpdir, "link")
     os.symlink(path, link)
-    with pytest.raises(OSError, match="symbolic link"):
-        # Skip this on MacOS Python 3.12?
+    # Error message changed at some point for Python 3.12
+    if sys.version_info >= "3.12.1":
+        error_msg = "None"
+    else:
+        error_msg = "symbolic link"
+    with pytest.raises(OSError, match=error_msg):
         audeer.rmdir(link, follow_symlink=False)
     assert os.path.exists(link)
     assert os.path.exists(path)


### PR DESCRIPTION
Under Linux and MacOS the error message when trying to delete a symlink with `audeer.rmdir(link, follow_symlink=False)` is broken for Python==3.12.4 (and maybe earlier versions as well.
We simply skip the comparison for now.