### PR TITLE
Add audeer.unique()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -34,6 +34,7 @@ from audeer.core.utils import run_worker_threads
 from audeer.core.utils import sort_versions
 from audeer.core.utils import to_list
 from audeer.core.utils import uid
+from audeer.core.utils import unique
 from audeer.core.version import LooseVersion
 from audeer.core.version import StrictVersion
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -829,3 +829,26 @@ def uid(
         uid = uid[-8:]
 
     return uid
+
+
+def unique(sequence: typing.Sequence) -> typing.List:
+    r"""Unique values as list preserving original order.
+
+    This is an alternative to ``list(set(x))``,
+    which returns the values in a non-deterministic order.
+
+    Args:
+        sequence: sequence of values
+
+    Returns:
+        unique values from ``x`` in order of appearance
+
+    Examples:
+        >>> unique([2, 2, 1])
+        [2, 1]
+
+    """
+    # https://stackoverflow.com/a/480227
+    seen = set()
+    seen_add = seen.add
+    return [x for x in sequence if not (x in seen or seen_add(x))]

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -832,10 +832,10 @@ def uid(
 
 
 def unique(sequence: typing.Sequence) -> typing.List:
-    r"""Unique values as list preserving original order.
+    r"""Unique values in its original order.
 
     This is an alternative to ``list(set(x))``,
-    which returns the values in a non-deterministic order.
+    which does not preserve the original order.
 
     Args:
         sequence: sequence of values
@@ -844,6 +844,8 @@ def unique(sequence: typing.Sequence) -> typing.List:
         unique values from ``x`` in order of appearance
 
     Examples:
+        >>> list(set([2, 2, 1]))
+        [1, 2]
         >>> unique([2, 2, 1])
         [2, 1]
 

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -831,7 +831,7 @@ def uid(
     return uid
 
 
-def unique(sequence: typing.Sequence) -> typing.List:
+def unique(sequence: typing.Iterable) -> typing.List:
     r"""Unique values in its original order.
 
     This is an alternative to ``list(set(x))``,

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -44,3 +44,4 @@ audeer
     to_list
     touch
     uid
+    unique

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -531,3 +531,27 @@ def test_uid(from_string, short):
             assert uid == uid2
         else:
             assert uid != uid2
+
+
+@pytest.mark.parametrize(
+    "sequence, expected",
+    [
+        ([], []),
+        ([1], [1]),
+        ([2, 1], [2, 1]),
+        ([2, 1, 2], [2, 1]),
+        (["a", 1, "a", 1], ["a", 1]),
+        ((1, 1), [1]),
+    ],
+)
+def test_unique(sequence, expected):
+    r"""Test audeer.unique().
+
+    Should return unique values in original order.
+
+    Args:
+        sequence: sequence if input values
+        expected: expected unique list
+
+    """
+    assert audeer.unique(sequence) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -542,6 +542,8 @@ def test_uid(from_string, short):
         ([2, 1, 2], [2, 1]),
         (["a", 1, "a", 1], ["a", 1]),
         ((1, 1), [1]),
+        ("dddnnfhg", ["d", "n", "f", "h", "g"]),
+        ([None, None], [None]),
     ],
 )
 def test_unique(sequence, expected):


### PR DESCRIPTION
It might be that a user wants to get unique values of a sequence, in the order they are appearing in that sequence.

![image](https://github.com/audeering/audeer/assets/173624/f49f3a26-b337-4cdc-bb91-86ffa60ba906)