### PR TITLE
DOC: fix return value of run_tasks()

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -541,7 +541,7 @@ def run_tasks(
     multiprocessing: bool = False,
     progress_bar: bool = False,
     task_description: str = None,
-) -> typing.Sequence[typing.Any]:
+) -> typing.List[typing.Any]:
     r"""Run parallel tasks using multprocessing.
 
     .. note:: Result values are returned in order of ``params``.
@@ -562,6 +562,9 @@ def run_tasks(
         progress_bar: show a progress bar
         task_description: task description
             that will be displayed next to progress bar
+
+    Returns:
+        list of computed results
 
     Examples:
         >>> power = lambda x, n: x**n


### PR DESCRIPTION
This fixes the docstring of `audeer.run_tasks()` by changing its return type from sequence to list, and adds missing documentation of its return value.

![image](https://github.com/audeering/audeer/assets/173624/9a529e9f-fa4b-4db4-abcd-347fe2a79fa8)
