### PR TITLE
Use smoothing=0 in audeer.progress_bar()

### DIFF
--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -104,6 +104,7 @@ def progress_bar(
         disable=disable,
         desc=format_display_message(desc, pbar=True),
         leave=config.TQDM_LEAVE,
+        smoothing=0,
     )
 
 


### PR DESCRIPTION
Closes https://github.com/audeering/audb/issues/442

This makes the estimation of the remaining time in the progress bar less eratic.

For a single thread it changed the behavior from

![bar-main](https://github.com/user-attachments/assets/c7f5a558-3414-46b9-bd6e-648cf2183670)

to

![bar](https://github.com/user-attachments/assets/f334e1ca-0b13-43cf-af17-2f52e5236904)

And when using 4 threads it changes the behavior from

![bar-main-num-workers](https://github.com/user-attachments/assets/3037da8f-1cda-4f9a-802b-40567d2b1e8c)

to

![bar-num-workers](https://github.com/user-attachments/assets/841a7256-f7db-416f-b7b9-29289e3a02a6)