### PR TITLE
Add audeer.script_dir()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -2,7 +2,6 @@ from audeer.core.config import config
 from audeer.core.io import basename_wo_ext
 from audeer.core.io import common_directory
 from audeer.core.io import create_archive
-from audeer.core.io import current_dir
 from audeer.core.io import download_url
 from audeer.core.io import extract_archive
 from audeer.core.io import extract_archives
@@ -15,6 +14,7 @@ from audeer.core.io import move
 from audeer.core.io import move_file
 from audeer.core.io import replace_file_extension
 from audeer.core.io import rmdir
+from audeer.core.io import script_dir
 from audeer.core.io import touch
 from audeer.core.path import path
 from audeer.core.path import safe_path

--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -2,6 +2,7 @@ from audeer.core.config import config
 from audeer.core.io import basename_wo_ext
 from audeer.core.io import common_directory
 from audeer.core.io import create_archive
+from audeer.core.io import current_dir
 from audeer.core.io import download_url
 from audeer.core.io import extract_archive
 from audeer.core.io import extract_archives

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1,6 +1,7 @@
 import errno
 import fnmatch
 import hashlib
+import inspect
 import itertools
 import os
 import platform
@@ -229,6 +230,21 @@ def create_archive(
         raise RuntimeError(
             f"You can only create a ZIP or TAR.GZ archive, " f"not {archive}"
         )
+
+
+def current_dir() -> str:
+    r"""Folder in which caller of this function is located.
+
+    Returns:
+        current directory of caller
+
+    Examples:
+        >>> os.path.basename(current_dir())
+        'audeer_core_io_current_dir0'
+
+    """
+    caller = inspect.stack()[1].filename
+    return os.path.dirname(os.path.realpath(caller))
 
 
 def download_url(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -232,30 +232,6 @@ def create_archive(
         )
 
 
-def current_dir() -> str:
-    r"""Folder in which caller of this function is located.
-
-    When called from a file,
-    it returns the directory,
-    in which the file is stored.
-    When called in an interactive session,
-    it returns the current directory
-    of the interactive session.
-
-    Returns:
-        current directory of caller
-
-    Examples:
-        >>> os.path.basename(current_dir())  # folder of docstring test
-        'audeer_core_io_current_dir0'
-
-    """
-    # See https://stackoverflow.com/a/37792573
-    caller = inspect.stack()[1].filename
-    # See https://stackoverflow.com/a/5137509
-    return os.path.dirname(os.path.realpath(caller))
-
-
 def download_url(
     url: str,
     destination: str,
@@ -1030,6 +1006,30 @@ def rmdir(
     path = safe_path(path, *paths, follow_symlink=follow_symlink)
     if os.path.exists(path):
         shutil.rmtree(path)
+
+
+def script_dir() -> str:
+    r"""Folder in which caller of this function is located.
+
+    When called from a file,
+    it returns the directory,
+    in which the file is stored.
+    When called in an interactive session,
+    it returns the current directory
+    of the interactive session.
+
+    Returns:
+        current directory of caller
+
+    Examples:
+        >>> os.path.basename(script_dir())  # folder of docstring test
+        'audeer_core_io_script_dir0'
+
+    """
+    # See https://stackoverflow.com/a/37792573
+    caller = inspect.stack()[1].filename
+    # See https://stackoverflow.com/a/5137509
+    return os.path.dirname(os.path.realpath(caller))
 
 
 def touch(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1015,7 +1015,7 @@ def script_dir() -> str:
     it returns the directory,
     in which the file is stored.
     When called in an interactive session,
-    it returns the current directory
+    it returns the current working directory
     of the interactive session.
 
     Returns:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -235,6 +235,13 @@ def create_archive(
 def current_dir() -> str:
     r"""Folder in which caller of this function is located.
 
+    When called from a file,
+    it returns the directory,
+    in which the file is stored.
+    When called in an interactive session,
+    it returns the current directory
+    of the interactive session.
+
     Returns:
         current directory of caller
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -246,7 +246,7 @@ def current_dir() -> str:
         current directory of caller
 
     Examples:
-        >>> os.path.basename(current_dir())
+        >>> os.path.basename(current_dir())  # folder of docstring test
         'audeer_core_io_current_dir0'
 
     """

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1026,9 +1026,15 @@ def script_dir() -> str:
         'audeer_core_io_script_dir0'
 
     """
-    # See https://stackoverflow.com/a/37792573
+    # Returning the script dir is usually done with
+    # `os.path.dirname(os.path.realpath(__file__))`,
+    # see https://stackoverflow.com/a/5137509.
+    # We cannot use `__file__` here,
+    # as this would always point to this file (`io.py`).
+    # Instead we find the script
+    # of the caller of `audeer.script_dir()`,
+    # see https://stackoverflow.com/a/37792573
     caller = inspect.stack()[1].filename
-    # See https://stackoverflow.com/a/5137509
     return os.path.dirname(os.path.realpath(caller))
 
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -250,7 +250,9 @@ def current_dir() -> str:
         'audeer_core_io_current_dir0'
 
     """
+    # See https://stackoverflow.com/a/37792573
     caller = inspect.stack()[1].filename
+    # See https://stackoverflow.com/a/5137509
     return os.path.dirname(os.path.realpath(caller))
 
 

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -11,7 +11,6 @@ audeer
     common_directory
     config
     create_archive
-    current_dir
     deprecated
     deprecated_default_value
     deprecated_keyword_argument
@@ -40,6 +39,7 @@ audeer
     rmdir
     run_tasks
     safe_path
+    script_dir
     sort_versions
     StrictVersion
     to_list

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -11,6 +11,7 @@ audeer
     common_directory
     config
     create_archive
+    current_dir
     deprecated
     deprecated_default_value
     deprecated_keyword_argument

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -425,14 +425,19 @@ def test_common_directory(dirs, expected):
     assert common == expected
 
 
-def test_current_dir():
+def test_current_dir(tmpdir):
     r"""Test estimation of current directory of caller.
 
     See https://stackoverflow.com/a/5137509.
 
+    Args:
+        tmpdir: tmpdir fixture
+
     """
-    current_dir = audeer.current_dir()
-    assert current_dir == os.path.dirname(os.path.realpath(__file__))
+    expected_current_dir = os.path.dirname(os.path.realpath(__file__))
+    assert audeer.current_dir() == expected_current_dir
+    os.chdir(tmpdir)
+    assert audeer.current_dir() == expected_current_dir
 
 
 def test_download_url(tmpdir):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1554,8 +1554,10 @@ def test_script_dir(tmpdir):
     """
     expected_script_dir = os.path.dirname(os.path.realpath(__file__))
     assert audeer.script_dir() == expected_script_dir
+    current_dir = os.getcwd()
     os.chdir(tmpdir)
     assert audeer.script_dir() == expected_script_dir
+    os.chdir(current_dir)
 
 
 def test_touch(tmpdir):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -425,6 +425,16 @@ def test_common_directory(dirs, expected):
     assert common == expected
 
 
+def test_current_dir():
+    r"""Test estimation of current directory of caller.
+
+    See https://stackoverflow.com/a/5137509.
+
+    """
+    current_dir = audeer.current_dir()
+    assert current_dir == os.path.dirname(os.path.realpath(__file__))
+
+
 def test_download_url(tmpdir):
     url = "https://audeering.github.io/audeer/_static/favicon.png"
     audeer.download_url(url, tmpdir)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -425,21 +425,6 @@ def test_common_directory(dirs, expected):
     assert common == expected
 
 
-def test_current_dir(tmpdir):
-    r"""Test estimation of current directory of caller.
-
-    See https://stackoverflow.com/a/5137509.
-
-    Args:
-        tmpdir: tmpdir fixture
-
-    """
-    expected_current_dir = os.path.dirname(os.path.realpath(__file__))
-    assert audeer.current_dir() == expected_current_dir
-    os.chdir(tmpdir)
-    assert audeer.current_dir() == expected_current_dir
-
-
 def test_download_url(tmpdir):
     url = "https://audeering.github.io/audeer/_static/favicon.png"
     audeer.download_url(url, tmpdir)
@@ -1556,6 +1541,21 @@ def test_rmdir(tmpdir):
     audeer.rmdir(link, follow_symlink=True)
     assert not os.path.exists(link)
     assert not os.path.exists(path)
+
+
+def test_script_dir(tmpdir):
+    r"""Test estimation of current directory of caller.
+
+    See https://stackoverflow.com/a/5137509.
+
+    Args:
+        tmpdir: tmpdir fixture
+
+    """
+    expected_script_dir = os.path.dirname(os.path.realpath(__file__))
+    assert audeer.script_dir() == expected_script_dir
+    os.chdir(tmpdir)
+    assert audeer.script_dir() == expected_script_dir
 
 
 def test_touch(tmpdir):


### PR DESCRIPTION
Very often, I add the following to the top of a script:

```python
CURRENT_DIR = os.path.dirname(os.path.realpath(__file__))
```
and I need to google it every time.

To make it easier to remember, this pull request proposes to add `audeer.script_dir()` which can be used instead.
When called in an interactive session, it returns the directory the user is located in.

![image](https://github.com/user-attachments/assets/0b5ebcfd-279b-4079-ac11-607cbb1bfe8a)