### PR TITLE
TST: use sybil for doctests

### DIFF
--- a/audeer/core/conftest.py
+++ b/audeer/core/conftest.py
@@ -1,13 +1,28 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+import os
+
 import pytest
+import sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import SkipParser
 
-import audeer
+
+# Collect doctests
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE), SkipParser()],
+    patterns=["*.py"],
+    fixtures=["run_in_tmpdir"],
+).pytest()
 
 
-@pytest.fixture(autouse=True)
-def docdir(doctest_namespace, request):
-    # make sure audeer is imported
-    doctest_namespace["audeer"] = audeer
-    # set temporal working directory in docstring examples
-    tmpdir = request.getfixturevalue("tmpdir")
-    with tmpdir.as_cwd():
-        yield
+@pytest.fixture(scope="function")
+def run_in_tmpdir(tmpdir_factory):
+    """Move to a persistent tmpdir for execution of a whole file."""
+    tmpdir = tmpdir_factory.mktemp("tmp")
+    current_dir = os.getcwd()
+    os.chdir(tmpdir)
+
+    yield
+
+    os.chdir(current_dir)

--- a/audeer/core/conftest.py
+++ b/audeer/core/conftest.py
@@ -1,5 +1,4 @@
 from doctest import ELLIPSIS
-from doctest import NORMALIZE_WHITESPACE
 import os
 
 import pytest
@@ -10,7 +9,7 @@ from sybil.parsers.rest import SkipParser
 
 # Collect doctests
 pytest_collect_file = sybil.Sybil(
-    parsers=[DocTestParser(optionflags=ELLIPSIS + NORMALIZE_WHITESPACE), SkipParser()],
+    parsers=[DocTestParser(optionflags=ELLIPSIS), SkipParser()],
     patterns=["*.py"],
     fixtures=["run_in_tmpdir"],
 ).pytest()

--- a/audeer/core/conftest.py
+++ b/audeer/core/conftest.py
@@ -1,18 +1,19 @@
 from doctest import ELLIPSIS
 import os
+import platform
 
 import pytest
 import sybil
 from sybil.parsers.rest import DocTestParser
 from sybil.parsers.rest import SkipParser
 
+import audeer
 
-# Collect doctests
-pytest_collect_file = sybil.Sybil(
-    parsers=[DocTestParser(optionflags=ELLIPSIS), SkipParser()],
-    patterns=["*.py"],
-    fixtures=["run_in_tmpdir"],
-).pytest()
+
+def imports(namespace):
+    """Provide Python modules to namespace."""
+    namespace["platform"] = platform
+    namespace["audeer"] = audeer
 
 
 @pytest.fixture(scope="function")
@@ -25,3 +26,12 @@ def run_in_tmpdir(tmpdir_factory):
     yield
 
     os.chdir(current_dir)
+
+
+# Collect doctests
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(optionflags=ELLIPSIS), SkipParser()],
+    patterns=["*.py"],
+    fixtures=["run_in_tmpdir"],
+    setup=imports,
+).pytest()

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -43,9 +43,13 @@ def basename_wo_ext(
     Returns:
         basename of directory or file without extension
 
+    ..
+        >>> import audeer
+        >>> import os
+
     Examples:
         >>> path = "/test/file.wav"
-        >>> basename_wo_ext(path)
+        >>> audeer.basename_wo_ext(path)
         'file'
 
     """
@@ -81,7 +85,7 @@ def common_directory(
         ...     "/home/user1/tmp/covert/operator",
         ...     "/home/user1/tmp/coven/members",
         ... ]
-        >>> common_directory(paths)
+        >>> audeer.common_directory(paths)
         '/home/user1/tmp'
 
     """
@@ -141,13 +145,16 @@ def create_archive(
             or a file in ``files`` is not below ``root``
 
     Examples:
-        >>> _ = touch("a.txt")
-        >>> _ = touch("b.txt")
-        >>> create_archive(".", None, "archive.zip")
-        >>> extract_archive("archive.zip", ".")
+        >>> file_a = audeer.touch("a.txt")
+        >>> folder = os.path.dirname(file_a)
+        >>> file_b = audeer.touch(folder, "b.txt")
+        >>> archive = audeer.path("archive.zip")
+        >>> audeer.create_archive(folder, None, archive)
+        >>> audeer.extract_archive(archive, ".")
         ['a.txt', 'b.txt']
-        >>> create_archive(".", ["a.txt"], "archive.tar.gz")
-        >>> extract_archive("archive.tar.gz", ".")
+        >>> archive = audeer.path("archive.tar.gz")
+        >>> audeer.create_archive(folder, ["a.txt"], archive)
+        >>> audeer.extract_archive(archive, ".")
         ['a.txt']
 
     """
@@ -252,7 +259,9 @@ def download_url(
         path of locally stored file
 
     Examples:
-        >>> dst = download_url("https://audeering.github.io/audeer/_static/favicon.png", ".")
+        >>> dst = audeer.download_url(
+        ...     "https://audeering.github.io/audeer/_static/favicon.png", "."
+        ... )
         >>> os.path.basename(dst)
         'favicon.png'
 
@@ -307,11 +316,13 @@ def extract_archive(
         RuntimeError: if ``archive`` is malformed
 
     Examples:
-        >>> _ = touch("a.txt")
-        >>> create_archive(".", None, "archive.zip")
-        >>> extract_archive("archive.zip", ".")
+        >>> folder = audeer.path(".")
+        >>> file = audeer.touch(folder, "a.txt")
+        >>> archive = audeer.path("archive.zip")
+        >>> audeer.create_archive(folder, None, archive)
+        >>> audeer.extract_archive(archive, ".")
         ['a.txt']
-        >>> extract_archive("archive.zip", "sub")
+        >>> audeer.extract_archive(archive, "sub")
         ['a.txt']
 
     """
@@ -425,11 +436,14 @@ def extract_archives(
         RuntimeError: if an archive file is malformed
 
     Examples:
-        >>> _ = touch("a.txt")
-        >>> create_archive(".", ["a.txt"], "archive.zip")
-        >>> _ = touch("b.txt")
-        >>> create_archive(".", ["b.txt"], "archive.tar.gz")
-        >>> extract_archives(["archive.zip", "archive.tar.gz"], ".")
+        >>> folder = audeer.path(".")
+        >>> _ = audeer.touch(folder, "a.txt")
+        >>> _ = audeer.touch(folder, "b.txt")
+        >>> archive_a = audeer.path("archive.zip")
+        >>> archive_b = audeer.path("archive.tar.gz")
+        >>> audeer.create_archive(folder, ["a.txt"], archive_a)
+        >>> audeer.create_archive(folder, ["b.txt"], archive_b)
+        >>> audeer.extract_archives([archive_a, archive_b], ".")
         ['a.txt', 'b.txt']
 
     """
@@ -469,7 +483,7 @@ def file_extension(
 
     Examples:
         >>> path = "/test/file.wav"
-        >>> file_extension(path)
+        >>> audeer.file_extension(path)
         'wav'
 
     """
@@ -500,24 +514,13 @@ def list_dir_names(
         FileNotFoundError: if path does not exists
 
     Examples:
-        >>> _ = mkdir("path", "a", ".b", "c")
-        >>> list_dir_names(
-        ...     "path",
-        ...     basenames=True,
-        ... )
+        >>> path = audeer.path("path")
+        >>> _ = mkdir(path, "a", ".b", "c")
+        >>> audeer.list_dir_names(path, basenames=True)
         ['a']
-        >>> list_dir_names(
-        ...     "path",
-        ...     basenames=True,
-        ...     recursive=True,
-        ... )
+        >>> audeer.list_dir_names(path, basenames=True, recursive=True)
         ['a', 'a/.b', 'a/.b/c']
-        >>> list_dir_names(
-        ...     "path",
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=False,
-        ... )
+        >>> audeer.list_dir_names(path, basenames=True, recursive=True, hidden=False)
         ['a']
 
     """
@@ -576,68 +579,35 @@ def list_file_names(
             and ``os.dirname(path)`` does not exist
 
     Examples:
-        >>> dir_path = mkdir("path")
-        >>> _ = touch(dir_path, "file.wav")
-        >>> _ = touch(dir_path, "File.wav")
-        >>> _ = touch(dir_path, ".lock")
-        >>> sub_dir_path = mkdir("path", "sub")
-        >>> _ = touch(sub_dir_path, "file.ogg")
-        >>> _ = touch(sub_dir_path, ".lock")
-        >>> list_file_names(
-        ...     dir_path,
-        ...     basenames=True,
-        ... )
+        >>> dir_path = audeer.mkdir("path")
+        >>> _ = audeer.touch(dir_path, "file.wav")
+        >>> _ = audeer.touch(dir_path, "File.wav")
+        >>> _ = audeer.touch(dir_path, ".lock")
+        >>> sub_dir_path = audeer.mkdir(dir_path, "sub")
+        >>> _ = audeer.touch(sub_dir_path, "file.ogg")
+        >>> _ = audeer.touch(sub_dir_path, ".lock")
+        >>> audeer.list_file_names(dir_path, basenames=True)
         ['File.wav', 'file.wav']
-        >>> list_file_names(
-        ...     dir_path,
-        ...     basenames=True,
-        ...     hidden=True,
-        ... )
+        >>> audeer.list_file_names(dir_path, basenames=True, hidden=True)
         ['.lock', 'File.wav', 'file.wav']
-        >>> list_file_names(
-        ...     dir_path,
-        ...     basenames=True,
-        ...     recursive=True,
-        ... )
+        >>> audeer.list_file_names(dir_path, basenames=True, recursive=True)
         ['File.wav', 'file.wav', 'sub/file.ogg']
-        >>> list_file_names(
-        ...     dir_path,
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=True,
-        ... )
+        >>> audeer.list_file_names(dir_path, basenames=True, recursive=True, hidden=True)
         ['.lock', 'File.wav', 'file.wav', 'sub/.lock', 'sub/file.ogg']
-        >>> list_file_names(
-        ...     os.path.join(dir_path, "f*"),
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=True,
-        ... )
+        >>> audeer.list_file_names(os.path.join(dir_path, "f*"), basenames=True, recursive=True)
         ['file.wav', 'sub/file.ogg']
-        >>> list_file_names(
-        ...     os.path.join(dir_path, "[fF]*"),
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=True,
+        >>> audeer.list_file_names(
+        ...     os.path.join(dir_path, "[fF]*"), basenames=True, recursive=True
         ... )
         ['File.wav', 'file.wav', 'sub/file.ogg']
-        >>> list_file_names(
-        ...     os.path.join(dir_path, "[!f]*"),
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=True,
+        >>> audeer.list_file_names(
+        ...     os.path.join(dir_path, "[!f]*"), basenames=True, recursive=True
         ... )
-        ['.lock', 'File.wav', 'sub/.lock']
-        >>> list_file_names(
-        ...     os.path.join(dir_path, "f*"),
-        ...     filetype="ogg",
-        ...     basenames=True,
-        ...     recursive=True,
-        ...     hidden=True,
-        ... )
+        ['File.wav']
+        >>> audeer.list_file_names(dir_path, filetype="ogg", basenames=True, recursive=True)
         ['sub/file.ogg']
 
-    """
+    """  # noqa: E501
     path = safe_path(path)
 
     if os.path.isdir(path):
@@ -736,8 +706,8 @@ def mkdir(
         absolute path to the created directory
 
     Examples:
-        >>> p = mkdir("path1", "path2", "path3")
-        >>> os.path.basename(p)
+        >>> path = audeer.mkdir("path1", "path2", "path3")
+        >>> os.path.basename(path)
         'path3'
 
     """
@@ -777,10 +747,10 @@ def md5(
         FileNotFoundError: if ``path`` does not exist
 
     Examples:
-        >>> path = touch("file.txt")
-        >>> md5(path)
+        >>> path = audeer.touch("file.txt")
+        >>> audeer.md5(path)
         'd41d8cd98f00b204e9800998ecf8427e'
-        >>> md5(".")
+        >>> audeer.md5(os.path.dirname(path))
         '3d8e577bddb17db339eae0b3d9bcf180'
 
     """
@@ -860,11 +830,11 @@ def move(
             (raised only under Windows)
 
     Examples:
-        >>> path = mkdir("folder")
-        >>> src_path = touch(path, "file1")
+        >>> path = audeer.mkdir("folder")
+        >>> src_path = audeer.touch(path, "file1")
         >>> dst_path = os.path.join(path, "file2")
-        >>> move(src_path, dst_path)
-        >>> list_file_names(path, basenames=True)
+        >>> audeer.move(src_path, dst_path)
+        >>> audeer.list_file_names(path, basenames=True)
         ['file2']
 
     """
@@ -892,11 +862,11 @@ def move_file(
         dst_path: destination file path
 
     Examples:
-        >>> path = mkdir("folder")
-        >>> src_path = touch(path, "file1")
+        >>> path = audeer.mkdir("folder")
+        >>> src_path = audeer.touch(path, "file1")
         >>> dst_path = os.path.join(path, "file2")
-        >>> move_file(src_path, dst_path)
-        >>> list_file_names(path, basenames=True)
+        >>> audeer.move_file(src_path, dst_path)
+        >>> audeer.list_file_names(path, basenames=True)
         ['file2']
 
     """
@@ -929,15 +899,15 @@ def replace_file_extension(
         path to file with a possibly new extension
 
     Examples:
-        >>> replace_file_extension("file.txt", "rst")
+        >>> audeer.replace_file_extension("file.txt", "rst")
         'file.rst'
-        >>> replace_file_extension("file", "rst")
+        >>> audeer.replace_file_extension("file", "rst")
         'file.rst'
-        >>> replace_file_extension("file.txt", "")
+        >>> audeer.replace_file_extension("file.txt", "")
         'file'
-        >>> replace_file_extension("file.tar.gz", "zip", ext="tar.gz")
+        >>> audeer.replace_file_extension("file.tar.gz", "zip", ext="tar.gz")
         'file.zip'
-        >>> replace_file_extension("file.zip", "rst", ext="txt")
+        >>> audeer.replace_file_extension("file.zip", "rst", ext="txt")
         'file.zip'
 
     """
@@ -995,11 +965,12 @@ def rmdir(
             and ``path`` is a symbolic link
 
     Examples:
-        >>> _ = mkdir("path1", "path2", "path3")
-        >>> list_dir_names("path1", basenames=True)
+        >>> path = audeer.mkdir("path1")
+        >>> _ = audeer.mkdir(path, "path2", "path3")
+        >>> audeer.list_dir_names(path, basenames=True)
         ['path2']
-        >>> rmdir("path1", "path2")
-        >>> list_dir_names("path1")
+        >>> audeer.rmdir(path, "path2")
+        >>> audeer.list_dir_names(path)
         []
 
     """
@@ -1022,8 +993,8 @@ def script_dir() -> str:
         current directory of caller
 
     Examples:
-        >>> os.path.basename(script_dir())  # folder of docstring test
-        'audeer_core_io_script_dir0'
+        >>> audeer.script_dir()  # location of this file
+        '...audeer/core'
 
     """
     # Returning the script dir is usually done with
@@ -1058,7 +1029,7 @@ def touch(
         expanded path to file
 
     Examples:
-        >>> path = touch("file.txt")
+        >>> path = audeer.touch("file.txt")
         >>> os.path.basename(path)
         'file.txt'
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -581,29 +581,29 @@ def list_file_names(
     Examples:
         >>> dir_path = audeer.mkdir("path")
         >>> _ = audeer.touch(dir_path, "file.wav")
-        >>> _ = audeer.touch(dir_path, "File.wav")
+        >>> _ = audeer.touch(dir_path, "album.wav")
         >>> _ = audeer.touch(dir_path, ".lock")
         >>> sub_dir_path = audeer.mkdir(dir_path, "sub")
         >>> _ = audeer.touch(sub_dir_path, "file.ogg")
         >>> _ = audeer.touch(sub_dir_path, ".lock")
         >>> audeer.list_file_names(dir_path, basenames=True)
-        ['File.wav', 'file.wav']
+        ['album.wav', 'file.wav']
         >>> audeer.list_file_names(dir_path, basenames=True, hidden=True)
-        ['.lock', 'File.wav', 'file.wav']
+        ['.lock', 'album.wav', 'file.wav']
         >>> audeer.list_file_names(dir_path, basenames=True, recursive=True)
-        ['File.wav', 'file.wav', 'sub/file.ogg']
+        ['album.wav', 'file.wav', 'sub/file.ogg']
         >>> audeer.list_file_names(dir_path, basenames=True, recursive=True, hidden=True)
-        ['.lock', 'File.wav', 'file.wav', 'sub/.lock', 'sub/file.ogg']
+        ['.lock', 'album.wav', 'file.wav', 'sub/.lock', 'sub/file.ogg']
         >>> audeer.list_file_names(os.path.join(dir_path, "f*"), basenames=True, recursive=True)
         ['file.wav', 'sub/file.ogg']
         >>> audeer.list_file_names(
-        ...     os.path.join(dir_path, "[fF]*"), basenames=True, recursive=True
+        ...     os.path.join(dir_path, "[fa]*"), basenames=True, recursive=True
         ... )
-        ['File.wav', 'file.wav', 'sub/file.ogg']
+        ['album.wav', 'file.wav', 'sub/file.ogg']
         >>> audeer.list_file_names(
         ...     os.path.join(dir_path, "[!f]*"), basenames=True, recursive=True
         ... )
-        ['File.wav']
+        ['album.wav']
         >>> audeer.list_file_names(dir_path, filetype="ogg", basenames=True, recursive=True)
         ['sub/file.ogg']
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -4,7 +4,6 @@ import hashlib
 import inspect
 import itertools
 import os
-import platform
 import shutil
 import tarfile
 import typing
@@ -15,18 +14,6 @@ from audeer.core.path import path as safe_path
 from audeer.core.tqdm import format_display_message
 from audeer.core.tqdm import progress_bar
 from audeer.core.utils import to_list
-
-
-# Exclude common_directory example from doctest
-# on Windows and MacOS
-# (which adds /System/Volumes/Data in front in the Github runner)
-# as it outputs a path in Linux syntax in the example
-if platform.system() in ["Darwin", "Windows"]:  # pragma: no cover
-    __doctest_skip__ = [
-        "common_directory",
-        "list_dir_names",
-        "list_file_names",
-    ]
 
 
 def basename_wo_ext(
@@ -42,10 +29,6 @@ def basename_wo_ext(
 
     Returns:
         basename of directory or file without extension
-
-    ..
-        >>> import audeer
-        >>> import os
 
     Examples:
         >>> path = "/test/file.wav"
@@ -78,9 +61,6 @@ def common_directory(
 
     Returns:
         part of the directory tree that is common to all the directories
-
-    ..
-        >>> import platform
 
     Examples:
         .. skip: start if(platform.system == "Windows")

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -79,7 +79,12 @@ def common_directory(
     Returns:
         part of the directory tree that is common to all the directories
 
+    ..
+        >>> import platform
+
     Examples:
+        .. skip: start if(platform.system == "Windows")
+
         >>> paths = [
         ...     "/home/user1/tmp/coverage/test",
         ...     "/home/user1/tmp/covert/operator",
@@ -87,6 +92,8 @@ def common_directory(
         ... ]
         >>> audeer.common_directory(paths)
         '/home/user1/tmp'
+
+        .. skip: end
 
     """
 
@@ -514,6 +521,8 @@ def list_dir_names(
         FileNotFoundError: if path does not exists
 
     Examples:
+        .. skip: start if(platform.system == "Windows")
+
         >>> path = audeer.path("path")
         >>> _ = mkdir(path, "a", ".b", "c")
         >>> audeer.list_dir_names(path, basenames=True)
@@ -522,6 +531,8 @@ def list_dir_names(
         ['a', 'a/.b', 'a/.b/c']
         >>> audeer.list_dir_names(path, basenames=True, recursive=True, hidden=False)
         ['a']
+
+        .. skip: end
 
     """
     path = safe_path(path)
@@ -579,6 +590,8 @@ def list_file_names(
             and ``os.dirname(path)`` does not exist
 
     Examples:
+        .. skip: start if(platform.system == "Windows")
+
         >>> dir_path = audeer.mkdir("path")
         >>> _ = audeer.touch(dir_path, "file.wav")
         >>> _ = audeer.touch(dir_path, "album.wav")
@@ -606,6 +619,8 @@ def list_file_names(
         ['album.wav']
         >>> audeer.list_file_names(dir_path, filetype="ogg", basenames=True, recursive=True)
         ['sub/file.ogg']
+
+        .. skip: end
 
     """  # noqa: E501
     path = safe_path(path)
@@ -993,6 +1008,8 @@ def script_dir() -> str:
         current directory of caller
 
     Examples:
+        .. skip: next if(platform.system == "Windows")
+
         >>> audeer.script_dir()  # location of this file
         '...audeer/core'
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -63,7 +63,7 @@ def common_directory(
         part of the directory tree that is common to all the directories
 
     Examples:
-        .. skip: start if(platform.system == "Windows")
+        .. skip: start if(platform.system() == "Windows")
 
         >>> paths = [
         ...     "/home/user1/tmp/coverage/test",
@@ -501,7 +501,7 @@ def list_dir_names(
         FileNotFoundError: if path does not exists
 
     Examples:
-        .. skip: start if(platform.system == "Windows")
+        .. skip: start if(platform.system() == "Windows")
 
         >>> path = audeer.path("path")
         >>> _ = mkdir(path, "a", ".b", "c")
@@ -570,7 +570,7 @@ def list_file_names(
             and ``os.dirname(path)`` does not exist
 
     Examples:
-        .. skip: start if(platform.system == "Windows")
+        .. skip: start if(platform.system() == "Windows")
 
         >>> dir_path = audeer.mkdir("path")
         >>> _ = audeer.touch(dir_path, "file.wav")
@@ -988,7 +988,7 @@ def script_dir() -> str:
         current directory of caller
 
     Examples:
-        .. skip: next if(platform.system == "Windows")
+        .. skip: next if(platform.system() == "Windows")
 
         >>> audeer.script_dir()  # location of this file
         '...audeer/core'

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -1,17 +1,5 @@
 import os
-import platform
 import typing
-
-
-# Exclude common_directory example from doctest
-# on Windows and MacOS
-# (which adds /System/Volumes/Data in front in the Github runner)
-# as it outputs a path in Linux syntax in the example
-if platform.system() in ["Darwin", "Windows"]:  # pragma: no cover
-    __doctest_skip__ = [
-        "path",
-        "safe_path",
-    ]
 
 
 def path(
@@ -44,12 +32,8 @@ def path(
     Returns:
         (joined and) expanded path
 
-    ..
-        >>> import audeer
-        >>> import platform
-
     Examples:
-        .. skip: start if(platform.system == "Windows")
+        .. skip: start if(platform.system() == "Windows")
 
         >>> home = audeer.path("~")
         >>> folder = audeer.path("~/path/.././path")
@@ -123,7 +107,7 @@ def safe_path(
         (joined and) expanded path
 
     Examples:
-        .. skip: start if(platform.system == "Windows")
+        .. skip: start if(platform.system() == "Windows")
 
         >>> home = audeer.safe_path("~")
         >>> folder = audeer.safe_path("~/path/.././path")

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -44,20 +44,23 @@ def path(
     Returns:
         (joined and) expanded path
 
+    ..
+        >>> import audeer
+
     Examples:
-        >>> home = path("~")
-        >>> folder = path("~/path/.././path")
+        >>> home = audeer.path("~")
+        >>> folder = audeer.path("~/path/.././path")
         >>> folder[len(home) + 1 :]
         'path'
-        >>> file = path("~/path/.././path", "./file.txt")
+        >>> file = audeer.path("~/path/.././path", "./file.txt")
         >>> file[len(home) + 1 :]
         'path/file.txt'
         >>> file = audeer.touch("file.txt")
-        >>> link = path("link.txt")
+        >>> link = audeer.path("link.txt")
         >>> os.symlink(file, link)
-        >>> os.path.basename(path(link))
+        >>> os.path.basename(audeer.path(link))
         'link.txt'
-        >>> os.path.basename(path(link, follow_symlink=True))
+        >>> os.path.basename(audeer.path(link, follow_symlink=True))
         'file.txt'
 
     """
@@ -115,19 +118,19 @@ def safe_path(
         (joined and) expanded path
 
     Examples:
-        >>> home = safe_path("~")
-        >>> folder = safe_path("~/path/.././path")
+        >>> home = audeer.safe_path("~")
+        >>> folder = audeer.safe_path("~/path/.././path")
         >>> folder[len(home) + 1 :]
         'path'
-        >>> file = safe_path("~/path/.././path", "./file.txt")
+        >>> file = audeer.safe_path("~/path/.././path", "./file.txt")
         >>> file[len(home) + 1 :]
         'path/file.txt'
         >>> file = audeer.touch("file.txt")
-        >>> link = path("link.txt")
+        >>> link = audeer.path("link.txt")
         >>> os.symlink(file, link)
-        >>> os.path.basename(path(link))
+        >>> os.path.basename(audeer.path(link))
         'link.txt'
-        >>> os.path.basename(path(link, follow_symlink=True))
+        >>> os.path.basename(audeer.path(link, follow_symlink=True))
         'file.txt'
 
     """

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -46,8 +46,11 @@ def path(
 
     ..
         >>> import audeer
+        >>> import platform
 
     Examples:
+        .. skip: start if(platform.system == "Windows")
+
         >>> home = audeer.path("~")
         >>> folder = audeer.path("~/path/.././path")
         >>> folder[len(home) + 1 :]
@@ -62,6 +65,8 @@ def path(
         'link.txt'
         >>> os.path.basename(audeer.path(link, follow_symlink=True))
         'file.txt'
+
+        .. skip: end
 
     """
     if paths:
@@ -118,6 +123,8 @@ def safe_path(
         (joined and) expanded path
 
     Examples:
+        .. skip: start if(platform.system == "Windows")
+
         >>> home = audeer.safe_path("~")
         >>> folder = audeer.safe_path("~/path/.././path")
         >>> folder[len(home) + 1 :]
@@ -132,6 +139,8 @@ def safe_path(
         'link.txt'
         >>> os.path.basename(audeer.path(link, follow_symlink=True))
         'file.txt'
+
+        .. skip: end
 
     """
     return _path(path, *paths, follow_symlink=follow_symlink)

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -22,9 +22,12 @@ def format_display_message(text: str, pbar: bool = False) -> str:
     Returns:
         formatted text message
 
+    ..
+        >>> import audeer
+
     Examples:
-        >>> config.TQDM_COLUMNS = 20
-        >>> format_display_message("Long text that will be shorten to fit")
+        >>> audeer.config.TQDM_COLUMNS = 20
+        >>> audeer.format_display_message("Long text that will be shorten to fit")
         'Long te...n to fit'
 
     """

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -22,9 +22,6 @@ def format_display_message(text: str, pbar: bool = False) -> str:
     Returns:
         formatted text message
 
-    ..
-        >>> import audeer
-
     Examples:
         >>> audeer.config.TQDM_COLUMNS = 20
         >>> audeer.format_display_message("Long text that will be shorten to fit")

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -45,8 +45,11 @@ def deprecated(
         removal_version: version the code will be removed
         alternative: alternative code to use
 
+    ..
+        >>> import audeer
+
     Examples:
-        >>> @deprecated(removal_version="2.0.0")
+        >>> @audeer.deprecated(removal_version="2.0.0")
         ... def deprecated_function():
         ...     pass
 
@@ -92,7 +95,7 @@ def deprecated_default_value(
         new_default_value: new default value
 
     Examples:
-        >>> @deprecated_default_value(
+        >>> @audeer.deprecated_default_value(
         ...     argument="foo",
         ...     change_in_version="2.0.0",
         ...     new_default_value="bar",
@@ -153,7 +156,7 @@ def deprecated_keyword_argument(
             from ``kwargs`` inside the decorated object
 
     Examples:
-        >>> @deprecated_keyword_argument(
+        >>> @audeer.deprecated_keyword_argument(
         ...     deprecated_argument="foo",
         ...     new_argument="bar",
         ...     removal_version="2.0.0",
@@ -209,9 +212,9 @@ def flatten_list(nested_list: typing.List) -> typing.List:
         flattened list
 
     Examples:
-        >>> flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]])
+        >>> audeer.flatten_list([1, 2, 3, [4], [], [[[[[[[[[5]]]]]]]]]])
         [1, 2, 3, 4, 5]
-        >>> flatten_list([[1, 2], 3])
+        >>> audeer.flatten_list([[1, 2], 3])
         [1, 2, 3]
 
     """
@@ -271,7 +274,9 @@ def git_repo_tags(
         list of tags
 
     Examples:
-        >>> git_repo_tags()
+        .. skip: next
+
+        >>> audeer.git_repo_tags()
         ['v1.0.0', 'v1.1.0', 'v2.0.0']
 
     """
@@ -309,7 +314,9 @@ def git_repo_version(
         version number
 
     Examples:
-        >>> git_repo_version()
+        .. skip: next
+
+        >>> audeer.git_repo_version()
         'v1.0.0'
 
     """
@@ -446,11 +453,11 @@ def is_semantic_version(version: str) -> bool:
         ``True`` if version is a semantic version
 
     Examples:
-        >>> is_semantic_version("v1")
+        >>> audeer.is_semantic_version("v1")
         False
-        >>> is_semantic_version("1.2.3-r3")
+        >>> audeer.is_semantic_version("1.2.3-r3")
         True
-        >>> is_semantic_version("v0.7.2-9-g1572b37")
+        >>> audeer.is_semantic_version("v0.7.2-9-g1572b37")
         True
 
     """
@@ -498,11 +505,11 @@ def is_uid(uid: str) -> bool:
         ``True`` if string is a unique identifier
 
     Examples:
-        >>> is_uid("626f68e6-d336-70b9-e753-ed9fad855840")
+        >>> audeer.is_uid("626f68e6-d336-70b9-e753-ed9fad855840")
         True
-        >>> is_uid("ad855840")
+        >>> audeer.is_uid("ad855840")
         True
-        >>> is_uid("not a unique identifier")
+        >>> audeer.is_uid("not a unique identifier")
         False
 
     """
@@ -575,7 +582,7 @@ def run_tasks(
     Examples:
         >>> power = lambda x, n: x**n
         >>> params = [([2, n], {}) for n in range(10)]
-        >>> run_tasks(power, params, num_workers=3)
+        >>> audeer.run_tasks(power, params, num_workers=3)
         [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 
     """
@@ -644,7 +651,7 @@ def run_worker_threads(
     Examples:
         >>> power = lambda x, n: x**n
         >>> params = [(2, n) for n in range(10)]
-        >>> run_worker_threads(power, params, num_workers=3)
+        >>> audeer.run_worker_threads(power, params, num_workers=3)
         [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
 
     """
@@ -749,7 +756,7 @@ def sort_versions(
         ...     "v1.0.0",
         ...     "v2.0.0-1-gdf29c4a",
         ... ]
-        >>> sort_versions(vers)
+        >>> audeer.sort_versions(vers)
         ['v1.0.0', '2.0.0', 'v2.0.0-1-gdf29c4a', '2.0.1']
 
     """
@@ -784,9 +791,9 @@ def to_list(x: typing.Any):
         input as a list
 
     Examples:
-        >>> to_list("abc")
+        >>> audeer.to_list("abc")
         ['abc']
-        >>> to_list((1, 2, 3))
+        >>> audeer.to_list((1, 2, 3))
         [1, 2, 3]
 
     """
@@ -822,9 +829,9 @@ def uid(
         unique identifier
 
     Examples:
-        >>> uid(from_string="example_string")
+        >>> audeer.uid(from_string="example_string")
         '626f68e6-d336-70b9-e753-ed9fad855840'
-        >>> uid(from_string="example_string", short=True)
+        >>> audeer.uid(from_string="example_string", short=True)
         'ad855840'
 
     """
@@ -857,7 +864,7 @@ def unique(sequence: typing.Iterable) -> typing.List:
     Examples:
         >>> list(set([2, 2, 1]))
         [1, 2]
-        >>> unique([2, 2, 1])
+        >>> audeer.unique([2, 2, 1])
         [2, 1]
 
     """

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -28,7 +28,7 @@ def deprecated(
     removal_version: str,
     alternative: str = None,
 ) -> typing.Callable:
-    """Mark code as deprecated.
+    r"""Mark code as deprecated.
 
     Provide a `decorator <https://www.python.org/dev/peps/pep-0318/>`_
     to mark functions/classes as deprecated.
@@ -41,12 +41,12 @@ def deprecated(
     with the next minor release (`X.(Y+1).Z`).
     Otherwise, choose the next major release (`(X+1).Y.Z`).
 
+    ..
+        >>> import audeer
+
     Args:
         removal_version: version the code will be removed
         alternative: alternative code to use
-
-    ..
-        >>> import audeer
 
     Examples:
         >>> @audeer.deprecated(removal_version="2.0.0")

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -41,9 +41,6 @@ def deprecated(
     with the next minor release (`X.(Y+1).Z`).
     Otherwise, choose the next major release (`(X+1).Y.Z`).
 
-    ..
-        >>> import audeer
-
     Args:
         removal_version: version the code will be removed
         alternative: alternative code to use

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -101,9 +101,6 @@ class StrictVersion(Version):
         ValueError: if ``version`` does not match
             the ``StrictVersion.version_re`` pattern
 
-    ..
-        >>> import audeer
-
     Examples:
         >>> v1 = audeer.StrictVersion("1.17.2a1")
         >>> v1

--- a/audeer/core/version.py
+++ b/audeer/core/version.py
@@ -101,15 +101,18 @@ class StrictVersion(Version):
         ValueError: if ``version`` does not match
             the ``StrictVersion.version_re`` pattern
 
+    ..
+        >>> import audeer
+
     Examples:
-        >>> v1 = StrictVersion("1.17.2a1")
+        >>> v1 = audeer.StrictVersion("1.17.2a1")
         >>> v1
         StrictVersion ('1.17.2a1')
         >>> v1.version
         (1, 17, 2)
         >>> v1.prerelease
         ('a', 1)
-        >>> v2 = StrictVersion("1.17.2")
+        >>> v2 = audeer.StrictVersion("1.17.2")
         >>> v1 < v2
         True
 
@@ -283,12 +286,12 @@ class LooseVersion(Version):
         version: version string
 
     Examples:
-        >>> v1 = LooseVersion("1.17.2")
+        >>> v1 = audeer.LooseVersion("1.17.2")
         >>> v1
         LooseVersion ('1.17.2')
         >>> v1.version
         [1, 17, 2]
-        >>> v2 = LooseVersion("1.17.2-3-g70b71bd")
+        >>> v2 = audeer.LooseVersion("1.17.2-3-g70b71bd")
         >>> v1 < v2
         True
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,9 @@
+import sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+
+
+pytest_collect_file = sybil.Sybil(
+    parsers=[DocTestParser(), PythonCodeBlockParser()],
+    pattern="*.rst",
+).pytest()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,24 +15,19 @@ to estimate Pi with a Monte Carlo method.
     import audeer
 
 
-    NUM_SAMPLES = int(1e6)
-
-
     def is_inside(p):
         x, y = random.random(), random.random()
         return x * x + y * y < 1
 
 
-    def main():
+    def pi(iterations=100_000):
         inside_samples = audeer.run_tasks(
             is_inside,
-            [([n], {}) for n in range(0, NUM_SAMPLES)],
+            [([n], {}) for n in range(0, iterations)],
             num_workers=4,
             progress_bar=True,
+            task_description="Estimate PI",
         )
-        pi = 4.0 * sum(inside_samples) / NUM_SAMPLES
-        print(f"Pi is roughly {pi}")
+        return 4.0 * sum(inside_samples) / iterations
 
-
-    if __name__ == "__main__":
-        main()
+>>> pi(1000)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -30,4 +30,6 @@ to estimate Pi with a Monte Carlo method.
         )
         return 4.0 * sum(inside_samples) / iterations
 
+>>> random.seed(1)
 >>> pi(1000)
+3.112

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ ignore-words-list = 'covert,te'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
+    -p no:doctest
     --cov=audeer
     --cov-fail-under=100
     --cov-report term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ addopts = '''
     --cov-fail-under=100
     --cov-report term-missing
     --cov-report xml
-    --ignore=docs/
 '''
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pytest<7.0.0
+pytest
 pytest-cov
-pytest-doctestplus
+sybil[pytest]


### PR DESCRIPTION
Similar to https://github.com/audeering/audb/pull/469 we switch to use sybil for doctests.

This has several motivations:
* add possibility to test the documentation
* remove dependency on `pytest-doctestplus` (slow in adopting to newer pytest versions)
* write expected results of code blocks as part of the usage documentation
* allow to use pytest fixtures inside doctests

Other changes:
* use fully qulified imports in docstring examples, e.g. `audeer.path()` instead of `path()`

## Summary by Sourcery

Switch to using Sybil for doctests, updating test configurations and requirements accordingly.

Enhancements:
- Switch to using Sybil for running doctests, replacing the previous method.

Tests:
- Update test requirements to include Sybil and remove pytest-doctestplus.
- Modify test configuration to disable doctest-plus and integrate Sybil for doctest collection.