### PR TITLE
TST: fix checking error message for Python>=3.12.4

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1530,7 +1530,7 @@ def test_rmdir(tmpdir):
         sys.version_info.minor,
         sys.version_info.micro,
     )
-    if python_version == (3, 12, 4) and platform.system() != "Windows":
+    if python_version >= (3, 12, 4) and platform.system() != "Windows":
         error_msg = "None"
     else:
         error_msg = "symbolic link"


### PR DESCRIPTION
The error message for a symbolic link stays `None` in Python 3.12.7. As the behavior was introduced in Python 3.12.4, we skip it now for Python >=3.12.4.

## Summary by Sourcery

Bug Fixes:
- Fix the error message check for symbolic links in tests for Python versions 3.12.4 and above.