### PR TITLE
TST: fix testing for no user warning

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,10 +69,9 @@ def test_deprecated_default_value():
         "The default of 'foo' will change from " "'foo' to 'bar' " "with version 1.0.0."
     )
     default_value = "foo"
-    with pytest.warns(None):
-        # no warning if we set value
-        function_with_deprecated_default_value(foo="foo")
-        function_with_deprecated_default_value(foo="bar")
+    # no warning if we set value
+    function_with_deprecated_default_value(foo="foo")
+    function_with_deprecated_default_value(foo="bar")
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -69,9 +69,11 @@ def test_deprecated_default_value():
         "The default of 'foo' will change from " "'foo' to 'bar' " "with version 1.0.0."
     )
     default_value = "foo"
-    # no warning if we set value
-    function_with_deprecated_default_value(foo="foo")
-    function_with_deprecated_default_value(foo="bar")
+    with warnings.catch_warnings():
+        # no warning if we set value
+        warnings.simplefilter("error")
+        function_with_deprecated_default_value(foo="foo")
+        function_with_deprecated_default_value(foo="bar")
     with warnings.catch_warnings(record=True) as w:
         # Cause all warnings to always be triggered.
         warnings.simplefilter("always")


### PR DESCRIPTION
We tested with `with pytest.warns(None)` that no user warning is raised, which was wrong and also raises an error since `pytest` > 7.0. As stated in the `pytest` [documentation](https://docs.pytest.org/en/7.0.x/how-to/capture-warnings.html#additional-use-cases-of-warnings-in-tests), one should use

```python
with warnings.catch_warnings():
    warnings.simplefilter("error")
    ...
```

to check that no warning is raised.

I updated the code accordingly.

## Summary by Sourcery

Bug Fixes:
- Fix testing for no user warning by replacing 'pytest.warns(None)' with 'warnings.catch_warnings()' and 'warnings.simplefilter("error")' to comply with pytest > 7.0.