### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Utilities',
 ]
 dependencies = [


### PR DESCRIPTION
This adds tests for Python 3.13, which has been released at 2024-10-07, and lists it as supported Python version in `pyproject.toml`.

## Summary by Sourcery

Add support for Python 3.13 by updating the CI configuration and build system to include it as a supported version.

Build:
- List Python 3.13 as a supported version in pyproject.toml.

CI:
- Add Python 3.13 to the CI testing matrix in GitHub Actions workflow.