### PR TITLE
Filter tar in extract_archive() for Python>=3.12

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -5,10 +5,10 @@ import inspect
 import itertools
 import os
 import shutil
+import sys
 import tarfile
 import typing
 import urllib.request
-import warnings
 import zipfile
 
 from audeer.core.path import path as safe_path
@@ -370,11 +370,16 @@ def extract_archive(
                     desc=desc,
                     disable=disable,
                 ):
-                    # In Python 3.12 the `filter` argument was introduced.
-                    # In a later version we should use `filter="tar"`,
-                    # until then we catch the deprecation warning
-                    with warnings.catch_warnings():
-                        warnings.simplefilter("ignore")
+                    # In Python 3.12 the `filter` argument was introduced,
+                    # and it will be set automatically in Python 3.14,
+                    # see
+                    # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
+                    # noqa: E501
+                    if sys.version_info >= (3, 12):
+                        tf.extract(
+                            member, destination, numeric_owner=True, filter="tar"
+                        )
+                    else:
                         tf.extract(member, destination, numeric_owner=True)
                 files = [m.name for m in members]
         else:

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -375,12 +375,10 @@ def extract_archive(
                     # see
                     # https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter
                     # noqa: E501
-                    if sys.version_info >= (3, 12):
-                        tf.extract(
-                            member, destination, numeric_owner=True, filter="tar"
-                        )
-                    else:
-                        tf.extract(member, destination, numeric_owner=True)
+                    kwargs = {"numeric_owner": True}
+                    if sys.version_info >= (3, 12):  # pragma: no cover
+                        kwargs = kwargs | {"filter": "tar"}
+                    tf.extract(member, destination, **kwargs)
                 files = [m.name for m in members]
         else:
             raise RuntimeError(

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -8,6 +8,7 @@ import shutil
 import tarfile
 import typing
 import urllib.request
+import warnings
 import zipfile
 
 from audeer.core.path import path as safe_path
@@ -369,7 +370,12 @@ def extract_archive(
                     desc=desc,
                     disable=disable,
                 ):
-                    tf.extract(member, destination, numeric_owner=True)
+                    # In Python 3.12 the `filter` argument was introduced.
+                    # In a later version we should use `filter="tar"`,
+                    # until then we catch the deprecation warning
+                    with warnings.catch_warnings():
+                        warnings.simplefilter("ignore")
+                        tf.extract(member, destination, numeric_owner=True)
                 files = [m.name for m in members]
         else:
             raise RuntimeError(


### PR DESCRIPTION
In Python 3.12 the `filter` argument was introduced to `TarFile.extract()`, see [tarfile.TarFile.extract](https://docs.python.org/3.12/library/tarfile.html#tarfile.TarFile.extract) and [tarfile-extraction-filter](https://docs.python.org/3.12/library/tarfile.html#tarfile-extraction-filter). 

When testing with Python 3.13 it raises the following deprecation warning:

```
.../audeer/core/io.py:374: DeprecationWarning: Python 3.14 will, by default,
filter extracted tar archives and reject files or modify their metadata.
Use the filter argument to control this behavior.
```

To avoid this, and make it also safe when Python 3.14 is introduced, this pull requests adds `filter="tar"` when extracting a tar archive in `audeer.extract_archive()` in Python >=3.12.

## Summary by Sourcery

Bug Fixes:
- Add the 'filter' argument to TarFile.extract() in extract_archive() for Python >=3.12 to prevent deprecation warnings in future Python versions.