### PR TITLE
Remove support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
@@ -29,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.13',
     'Topic :: Utilities',
 ]
+requires-python = '>=3.9'
 dependencies = [
     'tqdm',
 ]


### PR DESCRIPTION
Remove support and tests for Python 3.8.

## Summary by Sourcery

Drop support for Python 3.8.

Build:
- Remove Python 3.8 from the test matrix.

Chores:
- Remove Python 3.8 classifier and update `requires-python` in `pyproject.toml`.