### PR TITLE
Avoid using typing module

### DIFF
--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1,13 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import errno
 import fnmatch
 import hashlib
 import inspect
+import io
 import itertools
 import os
 import shutil
 import sys
 import tarfile
-import typing
 import urllib.request
 import zipfile
 
@@ -18,7 +21,7 @@ from audeer.core.utils import to_list
 
 
 def basename_wo_ext(
-    path: typing.Union[str, bytes],
+    path: str | bytes,
     *,
     ext: str = None,
 ) -> str:
@@ -50,7 +53,7 @@ def basename_wo_ext(
 
 
 def common_directory(
-    dirs: typing.Sequence[str],
+    dirs: Sequence[str],
     *,
     sep: str = os.path.sep,
 ) -> str:
@@ -94,7 +97,7 @@ def common_directory(
 
 def create_archive(
     root: str,
-    files: typing.Optional[typing.Union[str, typing.Sequence[str]]],
+    files: str | Sequence[str] | None,
     archive: str,
     *,
     verbose: bool = False,
@@ -292,7 +295,7 @@ def extract_archive(
     *,
     keep_archive: bool = True,
     verbose: bool = False,
-) -> typing.List[str]:
+) -> list[str]:
     r"""Extract ZIP or TAR file.
 
     Args:
@@ -411,12 +414,12 @@ def extract_archive(
 
 
 def extract_archives(
-    archives: typing.Sequence[str],
+    archives: Sequence[str],
     destination: str,
     *,
     keep_archive: bool = True,
     verbose: bool = False,
-) -> typing.List[str]:
+) -> list[str]:
     r"""Extract multiple ZIP or TAR archives at once.
 
     Args:
@@ -474,7 +477,7 @@ def extract_archives(
 
 
 def file_extension(
-    path: typing.Union[str, bytes],
+    path: str | bytes,
 ) -> str:
     """File extension.
 
@@ -495,12 +498,12 @@ def file_extension(
 
 
 def list_dir_names(
-    path: typing.Union[str, bytes],
+    path: str | bytes,
     *,
     basenames: bool = False,
     recursive: bool = False,
     hidden: bool = True,
-) -> typing.List[str]:
+) -> list[str]:
     """List of folder names located inside provided path.
 
     Args:
@@ -533,7 +536,7 @@ def list_dir_names(
     """
     path = safe_path(path)
 
-    def helper(p: str, paths: typing.List[str]):
+    def helper(p: str, paths: list[str]):
         ps = [os.path.join(p, x) for x in os.listdir(p)]
         ps = [x for x in ps if os.path.isdir(x)]
         if not hidden:
@@ -552,13 +555,13 @@ def list_dir_names(
 
 
 def list_file_names(
-    path: typing.Union[str, bytes],
+    path: str | bytes,
     *,
     filetype: str = "",
     basenames: bool = False,
     recursive: bool = False,
     hidden: bool = False,
-) -> typing.List[str]:
+) -> list[str]:
     """List of file names inferred from provided path.
 
     Args:
@@ -641,7 +644,7 @@ def list_file_names(
         if not os.path.isdir(folder):
             raise NotADirectoryError(folder)
 
-    def helper(p: str, paths: typing.List[str]):
+    def helper(p: str, paths: list[str]):
         ps = [os.path.join(p, x) for x in os.listdir(p)]
         folders = [x for x in ps if os.path.isdir(x)]
         files = [x for x in ps if os.path.isfile(x)]
@@ -685,8 +688,8 @@ def list_file_names(
 
 
 def mkdir(
-    path: typing.Union[str, bytes],
-    *paths: typing.Sequence[typing.Union[str, bytes]],
+    path: str | bytes,
+    *paths: Sequence[str | bytes],
     mode: int = 0o777,
 ) -> str:
     """Create directory.
@@ -802,7 +805,7 @@ def md5(
 
 
 def md5_read_chunk(
-    fp: typing.IO,
+    fp: io.IOBase,
     chunk_size: int = 8192,
 ):
     while True:
@@ -887,7 +890,7 @@ def move_file(
 
 
 def replace_file_extension(
-    path: typing.Union[str, bytes],
+    path: str | bytes,
     new_extension: str,
     *,
     ext: str = None,
@@ -952,8 +955,8 @@ def replace_file_extension(
 
 
 def rmdir(
-    path: typing.Union[str, bytes],
-    *paths: typing.Sequence[typing.Union[str, bytes]],
+    path: str | bytes,
+    *paths: Sequence[str | bytes],
     follow_symlink: bool = True,
 ):
     """Remove directory.
@@ -1025,8 +1028,8 @@ def script_dir() -> str:
 
 
 def touch(
-    path: typing.Union[str, bytes],
-    *paths: typing.Sequence[typing.Union[str, bytes]],
+    path: str | bytes,
+    *paths: Sequence[str | bytes],
 ) -> str:
     """Create an empty file.
 

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -45,8 +45,7 @@ def basename_wo_ext(
     if ext is not None:
         if not ext.startswith("."):
             ext = "." + ext  # 'mp3' => '.mp3'
-        if path.endswith(ext):
-            path = path[: -len(ext)]
+        path = path.removesuffix(ext)
     else:
         path = os.path.splitext(path)[0]
     return path
@@ -931,10 +930,8 @@ def replace_file_extension(
         ext = file_extension(path)
 
     # '.mp3' => 'mp3'
-    if ext.startswith("."):
-        ext = ext[1:]
-    if new_extension.startswith("."):
-        new_extension = new_extension[1:]
+    ext = ext.removeprefix(".")
+    new_extension = new_extension.removeprefix(".")
 
     if ext and not path.endswith(f".{ext}"):
         return path

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
 import os
-import typing
 
 
 def path(
-    path: typing.Union[str, bytes],
-    *paths: typing.Sequence[typing.Union[str, bytes]],
+    path: str | bytes,
+    *paths: Sequence[str | bytes],
     follow_symlink: bool = False,
 ) -> str:
     """Expand and normalize to absolute path.
@@ -73,8 +75,8 @@ _path = path
 
 
 def safe_path(
-    path: typing.Union[str, bytes],
-    *paths: typing.Sequence[typing.Union[str, bytes]],
+    path: str | bytes,
+    *paths: Sequence[str | bytes],
     follow_symlink: bool = False,
 ) -> str:
     """Expand and normalize to absolute path.

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -1,6 +1,6 @@
+from collections.abc import Sequence
 import threading
 import time
-import typing
 
 from tqdm import tqdm
 
@@ -44,7 +44,7 @@ def format_display_message(text: str, pbar: bool = False) -> str:
 
 
 def progress_bar(
-    iterable: typing.Sequence = None,
+    iterable: Sequence = None,
     *,
     total: int = None,
     desc: str = None,
@@ -109,7 +109,7 @@ def progress_bar(
 
 
 def tqdm_wrapper(
-    iterable: typing.Sequence,
+    iterable: Sequence,
     maximum_refresh_time: float,
     *args,
     **kwargs,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -1,4 +1,6 @@
+from collections.abc import Callable
 from collections.abc import Iterable
+from collections.abc import Sequence
 import concurrent.futures
 import copy
 import functools
@@ -12,7 +14,6 @@ import queue
 import subprocess
 import sys
 import threading
-import typing
 import uuid
 import warnings
 
@@ -27,7 +28,7 @@ def deprecated(
     *,
     removal_version: str,
     alternative: str = None,
-) -> typing.Callable:
+) -> Callable:
     r"""Mark code as deprecated.
 
     Provide a `decorator <https://www.python.org/dev/peps/pep-0318/>`_
@@ -76,8 +77,8 @@ def deprecated_default_value(
     *,
     argument: str,
     change_in_version: str,
-    new_default_value: typing.Any,
-) -> typing.Callable:
+    new_default_value: object,
+) -> Callable:
     """Mark default value of keyword argument as deprecated.
 
     Provide a `decorator <https://www.python.org/dev/peps/pep-0318/>`_
@@ -128,9 +129,9 @@ def deprecated_keyword_argument(
     deprecated_argument: str,
     removal_version: str,
     new_argument: str = None,
-    mapping: typing.Callable = None,
+    mapping: Callable = None,
     remove_from_kwargs: bool = True,
-) -> typing.Callable:
+) -> Callable:
     r"""Mark keyword argument as deprecated.
 
     Provide a `decorator <https://www.python.org/dev/peps/pep-0318/>`_
@@ -196,7 +197,7 @@ def deprecated_keyword_argument(
     return _deprecated
 
 
-def flatten_list(nested_list: typing.List) -> typing.List:
+def flatten_list(nested_list: list) -> list:
     """Flatten an arbitrarily nested list.
 
     Implemented without  recursion to avoid stack overflows.
@@ -254,7 +255,7 @@ def freeze_requirements(outfile: str):
 def git_repo_tags(
     *,
     v: bool = None,
-) -> typing.List:
+) -> list:
     r"""Get a list of available git tags.
 
     The tags are inferred by executing
@@ -533,11 +534,11 @@ def is_uid(uid: str) -> bool:
 
 
 def run_tasks(
-    task_func: typing.Callable,
-    params: typing.Sequence[
-        typing.Tuple[
-            typing.Sequence[typing.Any],
-            typing.Dict[str, typing.Any],
+    task_func: Callable,
+    params: Sequence[
+        tuple[
+            Sequence[object],
+            dict[str, object],
         ]
     ],
     *,
@@ -546,7 +547,7 @@ def run_tasks(
     progress_bar: bool = False,
     task_description: str = None,
     maximum_refresh_time: float = None,
-) -> typing.List[typing.Any]:
+) -> list[object]:
     r"""Run parallel tasks using multprocessing.
 
     .. note:: Result values are returned in order of ``params``.
@@ -623,13 +624,13 @@ def run_tasks(
 
 @deprecated(removal_version="2.0.0", alternative="run_tasks")
 def run_worker_threads(
-    task_fun: typing.Callable,
-    params: typing.Sequence[typing.Any] = None,
+    task_fun: Callable,
+    params: Sequence[object] = None,
     *,
     num_workers: int = None,
     progress_bar: bool = False,
     task_description: str = None,
-) -> typing.Sequence[typing.Any]:  # pragma: no cover
+) -> Sequence[object]:  # pragma: no cover
     r"""Run parallel tasks using worker threads.
 
     .. note:: Result values are returned in order of ``params``.
@@ -729,8 +730,8 @@ def run_worker_threads(
 
 
 def sort_versions(
-    versions: typing.List[str],
-) -> typing.List:
+    versions: list[str],
+) -> list[str]:
     """Sort version numbers.
 
     If a version starts with ``v``,
@@ -774,7 +775,7 @@ def sort_versions(
     return sorted(versions, key=sort_key)
 
 
-def to_list(x: typing.Any):
+def to_list(x: object):
     """Convert to list.
 
     If an iterable is passed,
@@ -846,7 +847,7 @@ def uid(
     return uid
 
 
-def unique(sequence: typing.Iterable) -> typing.List:
+def unique(sequence: Iterable) -> list:
     r"""Unique values in its original order.
 
     This is an alternative to ``list(set(x))``,

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -289,7 +289,7 @@ def git_repo_tags(
     if v:
         tags = [f"v{t}" if not t.startswith("v") else t for t in tags]
     else:
-        tags = [t[1:] if t.startswith("v") else t for t in tags]
+        tags = [t.removeprefix("v") for t in tags]
     return tags
 
 
@@ -473,8 +473,7 @@ def is_semantic_version(version: str) -> bool:
 
     x, y = version_parts[:2]
     # Ignore starting 'v'
-    if x.startswith("v"):
-        x = x[1:]
+    x = x.removeprefix("v")
 
     z = ".".join(version_parts[2:])
     # For Z, '-' and '+' are also allowed as separators,
@@ -768,8 +767,7 @@ def sort_versions(
             )
 
     def sort_key(value):
-        if value.startswith("v"):
-            value = value[1:]
+        value = value.removeprefix("v")
         return LooseVersion(value)
 
     return sorted(versions, key=sort_key)


### PR DESCRIPTION
In https://github.com/audeering/audeer/pull/167 I have removed support for Python 3.8, but not yet updated the syntax to Python 3.9+.

## Summary by Sourcery

Enhancements:
- Use the new Python 3.9+ union operator `|` for type hints.