### PR TITLE
Add audeer.suppress_stdout()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -33,6 +33,7 @@ from audeer.core.utils import is_uid
 from audeer.core.utils import run_tasks
 from audeer.core.utils import run_worker_threads
 from audeer.core.utils import sort_versions
+from audeer.core.utils import suppress_stdout
 from audeer.core.utils import to_list
 from audeer.core.utils import uid
 from audeer.core.utils import unique

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 from collections.abc import Sequence
 import concurrent.futures
 from contextlib import contextmanager
+from contextlib import redirect_stdout
 import copy
 import functools
 import hashlib
@@ -785,12 +786,8 @@ def suppress_stdout():
 
     """
     with open(os.devnull, "w") as devnull:
-        old_stdout = sys.stdout
-        sys.stdout = devnull
-        try:
+        with redirect_stdout(devnull):
             yield
-        finally:
-            sys.stdout = old_stdout
 
 
 def to_list(x: object):

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Sequence
 import concurrent.futures
+from contextlib import contextmanager
 import copy
 import functools
 import hashlib
@@ -769,6 +770,27 @@ def sort_versions(
         return LooseVersion(value)
 
     return sorted(versions, key=sort_key)
+
+
+@contextmanager
+def suppress_stdout():
+    """Suppress stdout output.
+
+    Any code run iside this context manager
+    does not produce stdout output.
+
+    Example:
+        >>> with suppress_stdout():
+        ...     print("Hello")
+
+    """
+    with open(os.devnull, "w") as devnull:
+        old_stdout = sys.stdout
+        sys.stdout = devnull
+        try:
+            yield
+        finally:
+            sys.stdout = old_stdout
 
 
 def to_list(x: object):

--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -776,7 +776,7 @@ def sort_versions(
 def suppress_stdout():
     """Suppress stdout output.
 
-    Any code run iside this context manager
+    Any code run inside this context manager
     does not produce stdout output.
 
     Example:

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -41,6 +41,7 @@ audeer
     safe_path
     script_dir
     sort_versions
+    suppress_stdout
     StrictVersion
     to_list
     touch

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -487,6 +487,68 @@ def test_sort_versions_errors(versions, error_message):
         audeer.sort_versions(versions)
 
 
+def test_suppress_stdout(capsys):
+    with audeer.suppress_stdout():
+        print("This should not appear")
+        print("Neither should this")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_suppress_stdout_nested(capsys):
+    with audeer.suppress_stdout():
+        print("Outer suppressed")
+        with audeer.suppress_stdout():
+            print("Inner suppressed")
+        print("Back to outer suppressed")
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_suppress_stdout_exception(capsys):
+    try:
+        with audeer.suppress_stdout():
+            print("This should not appear")
+            raise ValueError("Test exception")
+    except ValueError:
+        pass
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_suppress_stdout_restores_stdout(capsys):
+    print("Before suppression")
+
+    with audeer.suppress_stdout():
+        print("This should not appear")
+
+    print("After suppression")
+
+    captured = capsys.readouterr()
+    lines = captured.out.strip().split("\n")
+    assert "Before suppression" in lines[0]
+    assert "After suppression" in lines[1]
+    assert len(lines) == 2
+
+
+def test_suppress_stdout_stderr_unaffected(capsys):
+    import sys
+
+    with audeer.suppress_stdout():
+        print("This stdout should not appear")
+        print("This stderr should appear", file=sys.stderr)
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "This stderr should appear" in captured.err
+
+
 @pytest.mark.parametrize(
     "input,expected_output",
     [


### PR DESCRIPTION
Add `audeer.suppress_stdout()`. It's useful to suppress output of code that generates a lot of meaningless output which is not configurable by the user, e.g. external machine learning models.

<img width="719" height="268" alt="image" src="https://github.com/user-attachments/assets/eaa57544-f62e-4783-8d01-91ec46efd43c" />

## Summary by Sourcery

Introduce a context manager to temporarily suppress standard output during code execution.

New Features:
- Add audeer.suppress_stdout() context manager to silence stdout

Tests:
- Add tests to verify suppression of output, nested contexts, exception handling, restoration of stdout, and preservation of stderr