### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audeer/core/io.py
+++ b/audeer/core/io.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import errno
 import fnmatch

--- a/audeer/core/path.py
+++ b/audeer/core/path.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
 import os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Utilities',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'tqdm',
 ]


### PR DESCRIPTION
As Python 3.9 will reach its end of life this month, we remove it from the package.