### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Utilities',
 ]
 requires-python = '>=3.10'


### PR DESCRIPTION
Add support and tests for Python 3.14, which will be released this month.

## Summary by Sourcery

Add support for Python 3.14 by updating the CI workflow and project metadata

Enhancements:
- Add Python 3.14 trove classifier to pyproject.toml

CI:
- Include Python 3.14 in the GitHub Actions test matrix