### PR TITLE
Stop run_tasks() immediately at error/interruption

### DIFF
--- a/audeer/core/utils.py
+++ b/audeer/core/utils.py
@@ -618,7 +618,7 @@ def run_tasks(
                     for idx, future in enumerate(futures):
                         result = future.result()
                         results[idx] = result
-            except KeyboardInterrupt:  # pragma: no cover
+            except (Exception, KeyboardInterrupt):  # pragma: no cover
                 # Ensure all jobs are canceled immediately
                 pool.shutdown(wait=False, cancel_futures=True)
                 raise


### PR DESCRIPTION
When using `audeer.run_tasks()` with `num_workers` > 1 and then pressing Ctrl+C I was not able to stop it immediately, but had to press Ctrl+C at least a second time. This is fixed by the changes provided here.

A similar problem I observed from time to time when a job with multiple workers fails: it can take a long time until the error message is shown. This should also be fixed by the catching `Exception` besides `KeyboardInterrupt`.