### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 2.3.1 (2025-10-27)
+--------------------------
+
+* Fixed: ensure ``audeer.run_tasks()`` stops immediately
+  when using multiple workers
+  and one process fails or is interrupted by the user
+
+
 Version 2.3.0 (2025-09-08)
 --------------------------
 


### PR DESCRIPTION
<img width="697" height="118" alt="image" src="https://github.com/user-attachments/assets/3bec311b-7f7b-42ba-9c32-31d9e31bac7a" />

## Summary by Sourcery

Prepare and publish the 2.3.1 release by updating the project version and changelog.

Build:
- Bump project version to 2.3.1

Documentation:
- Update CHANGELOG.rst with release notes for version 2.3.1