### PR TITLE
TST: fix test skipping under Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ documentation = 'https://audeering.github.io/audeer/'
 # ===== Dependency groups =================================================
 [dependency-groups]
 dev = [
-    'pytest',
+    'pytest !=9.0.0',  # https://github.com/simplistix/sybil/issues/157
     'pytest-cov',
     'sphinx >=3.0.0',
     'sphinx-apipages >=0.1.2',


### PR DESCRIPTION
Skipping a test under Windows with `sybil` is broken with `pytest ==9.0.0` as discussed at https://github.com/simplistix/sybil/issues/157 and https://github.com/pytest-dev/pytest/issues/13895.