### PR TITLE
Change default look of audeer.progress_bar()

### DIFF
--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -10,20 +10,32 @@ class config:
 
     """
 
-    TQDM_BAR = "─╸━"
-    """Characters used for the progress bar.
+    TQDM_BAR = "╸"
+    """Character used for the progress bar.
 
-    The first character is used for the unfilled portion,
-    the last for the filled portion,
-    and any characters in between for fractional fills.
+    Used for both filled and unfilled portions
+    when :attr:`TQDM_BG_COLOUR` is set,
+    providing a uv-style dashed progress bar.
     Set to ``None`` to use the default ``tqdm`` bar characters.
     """
 
-    TQDM_COLOUR = "green"
-    """Colour of the progress bar.
+    TQDM_BG_COLOUR = "black"
+    """Colour for the unfilled portion of the progress bar.
 
-    Any colour string supported by ``tqdm``,
-    e.g. ``'green'``, ``'cyan'``, ``'#00ff00'``.
+    When set together with :attr:`TQDM_COLOUR`,
+    enables a dual-coloured progress bar.
+    Supports named colours
+    (e.g. ``'green'``, ``'cyan'``, ``'dark_grey'``)
+    and hex colours (e.g. ``'#808080'``).
+    Set to ``None`` to disable.
+    """
+
+    TQDM_COLOUR = "green"
+    """Colour for the filled portion of the progress bar.
+
+    Supports named colours
+    (e.g. ``'green'``, ``'cyan'``, ``'dark_grey'``)
+    and hex colours (e.g. ``'#00ff00'``).
     Set to ``None`` to disable colouring.
     """
 
@@ -31,7 +43,7 @@ class config:
     """Length of progress bar description."""
 
     TQDM_FORMAT = (
-        "{percentage:3.0f}%|{bar} [{elapsed}<{remaining}] "
+        "{percentage:3.0f}% {bar} {elapsed}<{remaining} "
         "{desc:" + str(TQDM_DESCLEN) + "}"
     )
     """Format of progress bars."""

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -10,6 +10,23 @@ class config:
 
     """
 
+    TQDM_BAR = "─╸━"
+    """Characters used for the progress bar.
+
+    The first character is used for the unfilled portion,
+    the last for the filled portion,
+    and any characters in between for fractional fills.
+    Set to ``None`` to use the default ``tqdm`` bar characters.
+    """
+
+    TQDM_COLOUR = "green"
+    """Colour of the progress bar.
+
+    Any colour string supported by ``tqdm``,
+    e.g. ``'green'``, ``'cyan'``, ``'#00ff00'``.
+    Set to ``None`` to disable colouring.
+    """
+
     TQDM_DESCLEN = 60
     """Length of progress bar description."""
 

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -95,7 +95,7 @@ def progress_bar(
     """
     if desc is None:
         desc = ""
-    return tqdm_wrapper(
+    kwargs = dict(
         iterable=iterable,
         maximum_refresh_time=maximum_refresh_time,
         ncols=config.TQDM_COLUMNS,
@@ -106,6 +106,11 @@ def progress_bar(
         leave=config.TQDM_LEAVE,
         smoothing=0,
     )
+    if config.TQDM_BAR is not None:
+        kwargs["ascii"] = config.TQDM_BAR
+    if config.TQDM_COLOUR is not None:
+        kwargs["colour"] = config.TQDM_COLOUR
+    return tqdm_wrapper(**kwargs)
 
 
 def tqdm_wrapper(

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -26,7 +26,7 @@ _ANSI_COLOURS = {
     "bright_cyan": 96,
     "bright_white": 97,
 }
-_ANSI_RESET = "\033[0m"
+_ANSI_COLOR_RESET = "\033[39m"
 
 # Placeholder characters used internally for the bar.
 # These are replaced with coloured bar characters in _ColouredTqdm.
@@ -58,7 +58,7 @@ class _ColouredTqdm(tqdm):
         filled = s.count(_PLACEHOLDER_FULL)
         unfilled = s.count(_PLACEHOLDER_EMPTY)
         bc = self._bar_char
-        colored = f"{self._fc}{bc * filled}{self._uc}{bc * unfilled}{_ANSI_RESET}"
+        colored = f"{self._fc}{bc * filled}{self._uc}{bc * unfilled}{_ANSI_COLOR_RESET}"
         start = s.find(_PLACEHOLDER_FULL) if filled else s.find(_PLACEHOLDER_EMPTY)
         if start >= 0:
             end = (

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -181,7 +181,7 @@ def progress_bar(
         kwargs["cls"]._uc = _ansi_colour(config.TQDM_BG_COLOUR)
     else:
         if config.TQDM_BAR is not None:
-            kwargs["ascii"] = config.TQDM_BAR
+            kwargs["ascii"] = f" {config.TQDM_BAR}"
         if config.TQDM_COLOUR is not None:
             kwargs["colour"] = config.TQDM_COLOUR
     return tqdm_wrapper(**kwargs)

--- a/audeer/core/tqdm.py
+++ b/audeer/core/tqdm.py
@@ -7,6 +7,71 @@ from tqdm import tqdm
 from audeer.core.config import config
 
 
+_ANSI_COLOURS = {
+    "black": 30,
+    "red": 31,
+    "green": 32,
+    "yellow": 33,
+    "blue": 34,
+    "magenta": 35,
+    "cyan": 36,
+    "white": 37,
+    "dark_grey": 90,
+    "dark_gray": 90,
+    "bright_red": 91,
+    "bright_green": 92,
+    "bright_yellow": 93,
+    "bright_blue": 94,
+    "bright_magenta": 95,
+    "bright_cyan": 96,
+    "bright_white": 97,
+}
+_ANSI_RESET = "\033[0m"
+
+# Placeholder characters used internally for the bar.
+# These are replaced with coloured bar characters in _ColouredTqdm.
+_PLACEHOLDER_FULL = "\u2588"  # █ (full block)
+_PLACEHOLDER_EMPTY = "\u2800"  # ⠀ (braille pattern blank)
+
+
+def _ansi_colour(colour):
+    """Convert a colour name or hex string to an ANSI escape code."""
+    if colour in _ANSI_COLOURS:
+        return f"\033[{_ANSI_COLOURS[colour]}m"
+    if isinstance(colour, str) and colour.startswith("#") and len(colour) == 7:
+        r = int(colour[1:3], 16)
+        g = int(colour[3:5], 16)
+        b = int(colour[5:7], 16)
+        return f"\033[38;2;{r};{g};{b}m"
+    return ""
+
+
+class _ColouredTqdm(tqdm):
+    """Tqdm subclass with dual-coloured bar."""
+
+    _bar_char = "\u2588"
+    _fc = ""
+    _uc = ""
+
+    def __str__(self):
+        s = super().__str__()
+        filled = s.count(_PLACEHOLDER_FULL)
+        unfilled = s.count(_PLACEHOLDER_EMPTY)
+        bc = self._bar_char
+        colored = f"{self._fc}{bc * filled}{self._uc}{bc * unfilled}{_ANSI_RESET}"
+        start = s.find(_PLACEHOLDER_FULL) if filled else s.find(_PLACEHOLDER_EMPTY)
+        if start >= 0:
+            end = (
+                max(
+                    s.rfind(_PLACEHOLDER_FULL),
+                    s.rfind(_PLACEHOLDER_EMPTY),
+                )
+                + 1
+            )
+            s = s[:start] + colored + s[end:]
+        return s
+
+
 def format_display_message(text: str, pbar: bool = False) -> str:
     """Ensure a fixed length of text printed to screen.
 
@@ -106,10 +171,19 @@ def progress_bar(
         leave=config.TQDM_LEAVE,
         smoothing=0,
     )
-    if config.TQDM_BAR is not None:
-        kwargs["ascii"] = config.TQDM_BAR
-    if config.TQDM_COLOUR is not None:
-        kwargs["colour"] = config.TQDM_COLOUR
+    if config.TQDM_COLOUR is not None and config.TQDM_BG_COLOUR is not None:
+        # Dual-colour mode: use placeholder ascii chars
+        # that get replaced with coloured bar chars in _ColouredTqdm
+        kwargs["ascii"] = f"{_PLACEHOLDER_EMPTY}{_PLACEHOLDER_FULL}"
+        kwargs["cls"] = _ColouredTqdm
+        kwargs["cls"]._bar_char = config.TQDM_BAR or _PLACEHOLDER_FULL
+        kwargs["cls"]._fc = _ansi_colour(config.TQDM_COLOUR)
+        kwargs["cls"]._uc = _ansi_colour(config.TQDM_BG_COLOUR)
+    else:
+        if config.TQDM_BAR is not None:
+            kwargs["ascii"] = config.TQDM_BAR
+        if config.TQDM_COLOUR is not None:
+            kwargs["colour"] = config.TQDM_COLOUR
     return tqdm_wrapper(**kwargs)
 
 
@@ -117,6 +191,7 @@ def tqdm_wrapper(
     iterable: Sequence,
     maximum_refresh_time: float,
     *args,
+    cls: type = tqdm,
     **kwargs,
 ) -> tqdm:
     r"""Tqdm progress bar wrapper to enforce update once a second.
@@ -135,13 +210,14 @@ def tqdm_wrapper(
             If ``None``,
             no refreshing is enforced
         args: arguments passed on to ``tqdm``
+        cls: tqdm class to instantiate
         kwargs: keyword arguments passed on to ``tqdm``
 
     Returns:
         progress bar object
 
     """
-    pbar = tqdm(iterable, *args, **kwargs)
+    pbar = cls(iterable, *args, **kwargs)
 
     def refresh():
         while not pbar.disable:

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -34,12 +34,55 @@ def test_progress_bar():
     assert audeer.config.TQDM_BG_COLOUR == "black"
     assert audeer.config.TQDM_DESCLEN == 60
     assert audeer.config.TQDM_FORMAT == (
-        "{percentage:3.0f}%|{bar} [{elapsed}<{remaining}] "
+        "{percentage:3.0f}% {bar} {elapsed}<{remaining} "
         "{desc:" + str(audeer.config.TQDM_DESCLEN) + "}"
     )
     pbar = audeer.progress_bar([0.1])
     for step in pbar:
         time.sleep(step)
+
+
+def test_ansi_colour():
+    """Test _ansi_colour with hex colours and invalid input."""
+    from audeer.core.tqdm import _ansi_colour
+
+    # Hex colour
+    assert _ansi_colour("#ff8000") == "\033[38;2;255;128;0m"
+    # Invalid/unknown colour returns empty string
+    assert _ansi_colour("nonexistent") == ""
+    assert _ansi_colour(123) == ""
+
+
+def test_progress_bar_no_bg_colour():
+    """Cover the else branch when TQDM_BG_COLOUR is None."""
+    original_bg = audeer.config.TQDM_BG_COLOUR
+    original_bar = audeer.config.TQDM_BAR
+    original_colour = audeer.config.TQDM_COLOUR
+    try:
+        # Both TQDM_BAR and TQDM_COLOUR set, but no BG colour
+        audeer.config.TQDM_BG_COLOUR = None
+        audeer.config.TQDM_BAR = "="
+        audeer.config.TQDM_COLOUR = "green"
+        pbar = audeer.progress_bar([0], disable=True)
+        for _ in pbar:
+            pass
+
+        # Only TQDM_COLOUR is None (no colour kwarg passed)
+        audeer.config.TQDM_COLOUR = None
+        audeer.config.TQDM_BAR = "="
+        pbar = audeer.progress_bar([0], disable=True)
+        for _ in pbar:
+            pass
+
+        # Both None
+        audeer.config.TQDM_BAR = None
+        pbar = audeer.progress_bar([0], disable=True)
+        for _ in pbar:
+            pass
+    finally:
+        audeer.config.TQDM_BG_COLOUR = original_bg
+        audeer.config.TQDM_BAR = original_bar
+        audeer.config.TQDM_COLOUR = original_colour
 
 
 def test_progress_bar_update():

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -29,6 +29,8 @@ def test_format_display_message(text):
 
 
 def test_progress_bar():
+    assert audeer.config.TQDM_BAR == "─╸━"
+    assert audeer.config.TQDM_COLOUR == "green"
     assert audeer.config.TQDM_DESCLEN == 60
     assert audeer.config.TQDM_FORMAT == (
         "{percentage:3.0f}%|{bar} [{elapsed}<{remaining}] "

--- a/tests/test_tqdm.py
+++ b/tests/test_tqdm.py
@@ -29,8 +29,9 @@ def test_format_display_message(text):
 
 
 def test_progress_bar():
-    assert audeer.config.TQDM_BAR == "─╸━"
+    assert audeer.config.TQDM_BAR == "╸"
     assert audeer.config.TQDM_COLOUR == "green"
+    assert audeer.config.TQDM_BG_COLOUR == "black"
     assert audeer.config.TQDM_DESCLEN == 60
     assert audeer.config.TQDM_FORMAT == (
         "{percentage:3.0f}%|{bar} [{elapsed}<{remaining}] "


### PR DESCRIPTION
Updates `audeer.progress_bar()` by allowing to modify it's colors more easily.

Also change to the following default look:

<img width="586" height="24" alt="image" src="https://github.com/user-attachments/assets/7be26771-7b83-4e4d-b504-74d7d8df3ed3" />

The foreground and background colors can be disabled by setting them to `None`:

```python
audeer.config.TQDM_COLOUR = None
audeer.config.TQDM_BG_COLOUR = None
```

The sign used for the progress bar can also be changed, e.g. to something simpler with:

```python
audeer.config.TQDM_BAR = "-"
```

but also to something more complicated by adding more then one character. It will then present those character after each other on the same position before continuing to the next position:

```python
audeer.config.TQDM_BAR = "▁▂▃▄▅▆▇█"
```

