### PR TITLE
Add audeer.load_configuration()

### DIFF
--- a/audeer/__init__.py
+++ b/audeer/__init__.py
@@ -1,4 +1,5 @@
 from audeer.core.config import config
+from audeer.core.config import load_configuration
 from audeer.core.io import basename_wo_ext
 from audeer.core.io import common_directory
 from audeer.core.io import create_archive

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -1,3 +1,152 @@
+from collections.abc import Sequence
+import json
+import os
+
+
+def load_configuration(
+    default_config_file: str,
+    user_config_files: str | Sequence[str] = None,
+    *,
+    env_prefix: str = None,
+    validate: callable = None,
+) -> dict:
+    r"""Load configuration from files and environment variables.
+
+    Configuration values are collected from,
+    in order of increasing precedence:
+
+    1. ``default_config_file``,
+       the configuration file shipped with a package
+    2. ``user_config_files``,
+       applied in the given order
+       (a later file overrides an earlier one)
+    3. environment variables,
+       if ``env_prefix`` is given
+
+    Environment variables are matched
+    against the upper-cased configuration keys,
+    prefixed with ``env_prefix`` and an underscore,
+    e.g. the key ``cache_root``
+    is overridden by ``<env_prefix>_CACHE_ROOT``.
+    The value of an environment variable is converted
+    to the type of the corresponding default value:
+    ``str`` values are used as they are,
+    ``bool``/``int``/``float`` values are cast,
+    and ``list``/``dict`` values are parsed as JSON.
+    Only keys already present in the configuration files
+    can be overridden by environment variables.
+
+    Missing or empty configuration files are skipped.
+
+    Reading configuration files requires ``pyyaml``,
+    which is installed with ``pip install audeer[yaml]``.
+
+    Args:
+        default_config_file: path to the configuration file
+            shipped with a package.
+            The file does not have to exist
+        user_config_files: path(s) to user configuration file(s),
+            applied in the given order.
+            Files do not have to exist
+        env_prefix: prefix of environment variables
+            used to override configuration values.
+            If ``None``, environment variables are ignored
+        validate: callable that receives the merged configuration
+            dictionary and raises an error if it is invalid.
+            It is applied once,
+            after files and environment variables are merged
+
+    Returns:
+        merged configuration dictionary
+
+    Raises:
+        ImportError: if ``pyyaml`` is not installed,
+            and a configuration file exists
+
+    Examples:
+        >>> import tempfile
+        >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
+        >>> _ = open(config_file, "w").write("cache_root: ~/cache\n")
+        >>> audeer.load_configuration(config_file)
+        {'cache_root': '~/cache'}
+
+    """
+    config = _load_configuration_file(default_config_file)
+
+    if user_config_files is not None:
+        if isinstance(user_config_files, str):
+            user_config_files = [user_config_files]
+        for user_config_file in user_config_files:
+            config.update(_load_configuration_file(user_config_file))
+
+    if env_prefix is not None:
+        _override_with_environment(config, env_prefix)
+
+    if validate is not None:
+        validate(config)
+
+    return config
+
+
+def _load_configuration_file(config_file: str) -> dict:
+    r"""Read a single configuration file.
+
+    Args:
+        config_file: path to a YAML configuration file.
+            The file does not have to exist
+
+    Returns:
+        configuration dictionary,
+        empty if the file is missing or empty
+
+    """
+    if not os.path.exists(config_file):
+        return {}
+
+    # ``pyyaml`` is an optional dependency (``audeer[yaml]``),
+    # imported lazily so that audeer's base install stays dependency-light
+    try:
+        import yaml
+    except ImportError:  # pragma: no cover
+        raise ImportError(
+            "Reading configuration files requires 'pyyaml'. "
+            "Install it with: pip install audeer[yaml]"
+        )
+
+    with open(config_file) as cf:
+        config = yaml.load(cf, Loader=yaml.SafeLoader)
+
+    return config or {}
+
+
+def _override_with_environment(
+    config: dict,
+    env_prefix: str,
+) -> None:
+    r"""Override configuration values with environment variables in place."""
+    for key, default_value in config.items():
+        name = f"{env_prefix}_{key.upper()}"
+        if name in os.environ:
+            config[key] = _parse_environment_value(
+                os.environ[name],
+                default_value,
+            )
+
+
+def _parse_environment_value(value: str, default_value: object) -> object:
+    r"""Convert an environment variable to the type of the default value."""
+    # ``bool`` has to be checked before ``int``
+    if isinstance(default_value, bool):
+        return value.lower() in ("1", "true", "yes", "on")
+    if isinstance(default_value, int):
+        return int(value)
+    if isinstance(default_value, float):
+        return float(value)
+    if isinstance(default_value, (list, dict)):
+        return json.loads(value)
+    return value
+
+
 class config:
     """Get/set defaults for :mod:`audeer`.
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -85,21 +85,21 @@ def load_configuration(
         {'cache_root': '~/cache'}
 
     """
-    config = _load_configuration_file(default_config_file)
+    cfg = _load_configuration_file(default_config_file)
 
     if user_config_files is not None:
         if isinstance(user_config_files, str):
             user_config_files = [user_config_files]
         for user_config_file in user_config_files:
-            config.update(_load_configuration_file(user_config_file))
+            cfg.update(_load_configuration_file(user_config_file))
 
     if env_prefix is not None:
-        _override_with_environment(config, env_prefix)
+        _override_with_environment(cfg, env_prefix)
 
     if validate is not None:
-        validate(config)
+        validate(cfg)
 
-    return config
+    return cfg
 
 
 def _load_configuration_file(config_file: str) -> dict:
@@ -128,29 +128,29 @@ def _load_configuration_file(config_file: str) -> dict:
         )
 
     with open(config_file) as cf:
-        config = yaml.load(cf, Loader=yaml.SafeLoader)
+        cfg = yaml.load(cf, Loader=yaml.SafeLoader)
 
     # A file with only comments or whitespace also yields ``None``
-    if config is None:
+    if cfg is None:
         return {}
-    if not isinstance(config, Mapping):
+    if not isinstance(cfg, Mapping):
         raise ValueError(
             f"The configuration file '{config_file}' "
             f"must contain a mapping of key-value pairs, "
-            f"but contains a '{type(config).__name__}'."
+            f"but contains a '{type(cfg).__name__}'."
         )
-    return dict(config)
+    return dict(cfg)
 
 
 def _override_with_environment(
-    config: dict,
+    cfg: dict,
     env_prefix: str,
 ) -> None:
     r"""Override configuration values with environment variables in place."""
-    for key, default_value in config.items():
+    for key, default_value in cfg.items():
         name = f"{env_prefix}_{key.upper()}"
         if name in os.environ:
-            config[key] = _parse_environment_value(
+            cfg[key] = _parse_environment_value(
                 name,
                 os.environ[name],
                 default_value,

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -16,7 +16,7 @@ def load_configuration(
     in order of increasing precedence:
 
     1. ``default_config_file``,
-       the configuration file shipped with a package
+       e.g. the configuration file shipped with a package
     2. ``user_config_files``,
        applied in the given order
        (a later file overrides an earlier one)
@@ -39,11 +39,10 @@ def load_configuration(
     Missing or empty configuration files are skipped.
 
     Reading configuration files requires ``pyyaml``,
-    which is installed with ``pip install audeer[yaml]``.
+    which is installed when depending on ``audeer[yaml]``.
 
     Args:
-        default_config_file: path to the configuration file
-            shipped with a package.
+        default_config_file: path to default configuration file.
             The file does not have to exist
         user_config_files: path(s) to user configuration file(s),
             applied in the given order.
@@ -103,14 +102,13 @@ def _load_configuration_file(config_file: str) -> dict:
     if not os.path.exists(config_file):
         return {}
 
-    # ``pyyaml`` is an optional dependency (``audeer[yaml]``),
-    # imported lazily so that audeer's base install stays dependency-light
+    # Import lazily as ``pyyaml`` is an optional dependency
     try:
         import yaml
     except ImportError:  # pragma: no cover
         raise ImportError(
             "Reading configuration files requires 'pyyaml'. "
-            "Install it with: pip install audeer[yaml]"
+            "Install it with: uv pip install audeer[yaml]"
         )
 
     with open(config_file) as cf:

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -80,7 +80,8 @@ def load_configuration(
     Examples:
         >>> import tempfile
         >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
-        >>> _ = open(config_file, "w").write("cache_root: ~/cache\n")
+        >>> with open(config_file, "w") as file:
+        ...     _ = file.write("cache_root: ~/cache\n")
         >>> audeer.load_configuration(config_file)
         {'cache_root': '~/cache'}
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -107,7 +107,8 @@ def _load_configuration_file(config_file: str) -> dict:
         empty if the file is missing or empty
 
     """
-    if not os.path.exists(config_file):
+    # Skip missing or empty files
+    if not os.path.exists(config_file) or os.path.getsize(config_file) == 0:
         return {}
 
     # Import lazily as ``pyyaml`` is an optional dependency
@@ -122,6 +123,7 @@ def _load_configuration_file(config_file: str) -> dict:
     with open(config_file) as cf:
         config = yaml.load(cf, Loader=yaml.SafeLoader)
 
+    # A file with only comments or whitespace also yields ``None``
     if config is None:
         return {}
     if not isinstance(config, Mapping):

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -3,7 +3,6 @@ from collections.abc import Mapping
 from collections.abc import Sequence
 import json
 import os
-from typing import Any
 
 
 def load_configuration(
@@ -11,7 +10,7 @@ def load_configuration(
     user_config_files: str | Sequence[str] | None = None,
     *,
     env_prefix: str | None = None,
-    validate: Callable[[dict], Any] | None = None,
+    validate: Callable[[dict], None] | None = None,
 ) -> dict:
     r"""Load configuration from files and environment variables.
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -34,8 +34,15 @@ def load_configuration(
     The value of an environment variable is converted
     to the type of the corresponding default value:
     ``str`` values are used as they are,
-    ``bool``/``int``/``float`` values are cast,
+    ``int``/``float`` values are cast,
     and ``list``/``dict`` values are parsed as JSON.
+    A ``bool`` value is ``True``
+    for ``"1"``, ``"true"``, ``"yes"``, ``"on"``
+    (case insensitive)
+    and ``False`` for any other value;
+    a boolean is therefore never rejected,
+    whereas ``int``, ``float`` and JSON conversions
+    raise a ``ValueError`` on invalid input.
     Only keys already present in the configuration files
     can be overridden by environment variables.
 
@@ -157,7 +164,9 @@ def _parse_environment_value(
 ) -> object:
     r"""Convert an environment variable to the type of the default value."""
     try:
-        # ``bool`` has to be checked before ``int``
+        # ``bool`` has to be checked before ``int``.
+        # A boolean never fails conversion:
+        # any value other than the truthy ones becomes ``False``
         if isinstance(default_value, bool):
             return value.lower() in ("1", "true", "yes", "on")
         if isinstance(default_value, int):

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -1,14 +1,17 @@
+from collections.abc import Callable
+from collections.abc import Mapping
 from collections.abc import Sequence
 import json
 import os
+from typing import Any
 
 
 def load_configuration(
     default_config_file: str,
-    user_config_files: str | Sequence[str] = None,
+    user_config_files: str | Sequence[str] | None = None,
     *,
-    env_prefix: str = None,
-    validate: callable = None,
+    env_prefix: str | None = None,
+    validate: Callable[[dict], Any] | None = None,
 ) -> dict:
     r"""Load configuration from files and environment variables.
 
@@ -61,6 +64,11 @@ def load_configuration(
     Raises:
         ImportError: if ``pyyaml`` is not installed,
             and a configuration file exists
+        ValueError: if a configuration file
+            does not contain a mapping of key-value pairs
+        ValueError: if an environment variable
+            cannot be converted to the type
+            of the corresponding default value
 
     Examples:
         >>> import tempfile
@@ -114,7 +122,15 @@ def _load_configuration_file(config_file: str) -> dict:
     with open(config_file) as cf:
         config = yaml.load(cf, Loader=yaml.SafeLoader)
 
-    return config or {}
+    if config is None:
+        return {}
+    if not isinstance(config, Mapping):
+        raise ValueError(
+            f"The configuration file '{config_file}' "
+            f"must contain a mapping of key-value pairs, "
+            f"but contains a '{type(config).__name__}'."
+        )
+    return dict(config)
 
 
 def _override_with_environment(
@@ -126,22 +142,36 @@ def _override_with_environment(
         name = f"{env_prefix}_{key.upper()}"
         if name in os.environ:
             config[key] = _parse_environment_value(
+                name,
                 os.environ[name],
                 default_value,
             )
 
 
-def _parse_environment_value(value: str, default_value: object) -> object:
+def _parse_environment_value(
+    name: str,
+    value: str,
+    default_value: object,
+) -> object:
     r"""Convert an environment variable to the type of the default value."""
-    # ``bool`` has to be checked before ``int``
-    if isinstance(default_value, bool):
-        return value.lower() in ("1", "true", "yes", "on")
-    if isinstance(default_value, int):
-        return int(value)
-    if isinstance(default_value, float):
-        return float(value)
-    if isinstance(default_value, (list, dict)):
-        return json.loads(value)
+    try:
+        # ``bool`` has to be checked before ``int``
+        if isinstance(default_value, bool):
+            return value.lower() in ("1", "true", "yes", "on")
+        if isinstance(default_value, int):
+            return int(value)
+        if isinstance(default_value, float):
+            return float(value)
+        # ``json.JSONDecodeError`` is a subclass of ``ValueError``
+        if isinstance(default_value, (list, dict)):
+            return json.loads(value)
+    except ValueError as ex:
+        raise ValueError(
+            f"The environment variable '{name}={value}' "
+            f"could not be converted to the type "
+            f"'{type(default_value).__name__}' "
+            f"of the corresponding configuration value."
+        ) from ex
     return value
 
 

--- a/docs/api-src/audeer.rst
+++ b/docs/api-src/audeer.rst
@@ -28,6 +28,7 @@ audeer
     is_uid
     list_dir_names
     list_file_names
+    load_configuration
     load_json
     LooseVersion
     md5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
 # (needs setuptools_scm tools config below)
 dynamic = ['version']
 
+[project.optional-dependencies]
+# Reading configuration files with audeer.load_configuration()
+yaml = ['pyyaml']
+
 [project.urls]
 repository = 'https://github.com/audeering/audeer/'
 documentation = 'https://audeering.github.io/audeer/'
@@ -46,6 +50,7 @@ documentation = 'https://audeering.github.io/audeer/'
 dev = [
     'pytest !=9.0.0',  # https://github.com/simplistix/sybil/issues/157
     'pytest-cov',
+    'pyyaml',  # for audeer.load_configuration()
     'sphinx >=3.0.0',
     'sphinx-apipages >=0.1.2',
     'sphinx-audeering-theme >=1.1.4',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,16 @@ def test_load_configuration_empty_file(tmpdir):
     assert audeer.load_configuration(config_file) == {}
 
 
+def test_load_configuration_comments_only_file(tmpdir):
+    # A non-empty file that only contains comments or whitespace
+    # is parsed as ``None`` and returns an empty dictionary
+    config_file = write_config(
+        audeer.path(tmpdir, "comment.yaml"),
+        "# only a comment\n",
+    )
+    assert audeer.load_configuration(config_file) == {}
+
+
 def test_load_configuration_default(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -57,6 +57,19 @@ def test_load_configuration_user_file(tmpdir):
     }
 
 
+def test_load_configuration_missing_user_file(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    user_file = audeer.path(tmpdir, "missing.yaml")
+    # A non-existing user file is skipped,
+    # the default configuration is kept
+    assert audeer.load_configuration(default_file, user_file) == {
+        "cache_root": "~/cache",
+    }
+
+
 def test_load_configuration_multiple_user_files(tmpdir):
     default_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,134 @@
+import pytest
+
+import audeer
+
+
+def write_config(path, content):
+    r"""Write ``content`` to ``path`` and return the path."""
+    with open(path, "w") as fp:
+        fp.write(content)
+    return path
+
+
+def test_load_configuration_missing_file(tmpdir):
+    # Non-existing file returns empty dictionary
+    config_file = audeer.path(tmpdir, "missing.yaml")
+    assert audeer.load_configuration(config_file) == {}
+
+
+def test_load_configuration_empty_file(tmpdir):
+    # Empty file returns empty dictionary
+    config_file = write_config(audeer.path(tmpdir, "empty.yaml"), "")
+    assert audeer.load_configuration(config_file) == {}
+
+
+def test_load_configuration_default(tmpdir):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    assert audeer.load_configuration(config_file) == {"cache_root": "~/cache"}
+
+
+def test_load_configuration_user_file(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\nshared: /data\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    # User file overrides default,
+    # values only in default are kept
+    assert audeer.load_configuration(default_file, user_file) == {
+        "cache_root": "~/user",
+        "shared": "/data",
+    }
+
+
+def test_load_configuration_multiple_user_files(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    user_file_1 = write_config(
+        audeer.path(tmpdir, "user1.yaml"),
+        "cache_root: ~/user1\n",
+    )
+    user_file_2 = write_config(
+        audeer.path(tmpdir, "user2.yaml"),
+        "cache_root: ~/user2\n",
+    )
+    # A later file overrides an earlier one
+    assert audeer.load_configuration(
+        default_file,
+        [user_file_1, user_file_2],
+    ) == {"cache_root": "~/user2"}
+
+
+def test_load_configuration_environment(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        (
+            "name: default\n"
+            "count: 1\n"
+            "ratio: 1.5\n"
+            "enabled: false\n"
+            "repositories:\n"
+            "  - name: r1\n"
+            "    host: h1\n"
+        ),
+    )
+    # No override without a prefix,
+    # even if matching variables are set
+    monkeypatch.setenv("PKG_NAME", "env")
+    assert audeer.load_configuration(config_file)["name"] == "default"
+
+    # Values are cast to the type of the default value
+    monkeypatch.setenv("PKG_NAME", "env")
+    monkeypatch.setenv("PKG_COUNT", "5")
+    monkeypatch.setenv("PKG_RATIO", "2.5")
+    monkeypatch.setenv("PKG_ENABLED", "true")
+    monkeypatch.setenv(
+        "PKG_REPOSITORIES",
+        '[{"name": "r2", "host": "h2"}]',
+    )
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {
+        "name": "env",
+        "count": 5,
+        "ratio": 2.5,
+        "enabled": True,
+        "repositories": [{"name": "r2", "host": "h2"}],
+    }
+
+
+def test_load_configuration_environment_bool_false(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "enabled: true\n",
+    )
+    monkeypatch.setenv("PKG_ENABLED", "no")
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {"enabled": False}
+
+
+def test_load_configuration_validate(tmpdir):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+
+    calls = []
+
+    def validate(config):
+        calls.append(config)
+        if "repositories" not in config:
+            raise ValueError("Missing repositories.")
+
+    with pytest.raises(ValueError, match="Missing repositories."):
+        audeer.load_configuration(config_file, validate=validate)
+
+    # validate() received the merged configuration
+    assert calls == [{"cache_root": "~/cache"}]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -114,6 +114,37 @@ def test_load_configuration_environment_bool_false(tmpdir, monkeypatch):
     assert config == {"enabled": False}
 
 
+def test_load_configuration_non_mapping(tmpdir):
+    # A file that does not contain a mapping raises an error
+    config_file = write_config(
+        audeer.path(tmpdir, "list.yaml"),
+        "- a\n- b\n",
+    )
+    with pytest.raises(ValueError, match="must contain a mapping"):
+        audeer.load_configuration(config_file)
+
+
+@pytest.mark.parametrize(
+    "content, name, value",
+    [
+        ("count: 1\n", "PKG_COUNT", "not-an-int"),
+        ("ratio: 1.5\n", "PKG_RATIO", "not-a-float"),
+        ("items:\n  - a\n", "PKG_ITEMS", "not-json"),
+    ],
+)
+def test_load_configuration_environment_invalid(
+    tmpdir,
+    monkeypatch,
+    content,
+    name,
+    value,
+):
+    config_file = write_config(audeer.path(tmpdir, "default.yaml"), content)
+    monkeypatch.setenv(name, value)
+    with pytest.raises(ValueError, match="could not be converted to the type"):
+        audeer.load_configuration(config_file, env_prefix="PKG")
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,12 +7,8 @@ import pytest
 import audeer
 
 
-# Package whose distribution name (``attrs``)
-# differs from its import name (``attr``),
-# has no dependencies,
-# and is not a dependency of audeer
-PACKAGE = "attrs"
-MODULE = "attr"
+PACKAGE = "python-dotenv"
+MODULE = "dotenv"
 
 
 def uninstall():
@@ -52,25 +48,25 @@ def test():
     # install package
     audeer.install_package(
         PACKAGE,
-        version="<=24.2.0",
+        version="<=1.1.0",
     )
 
     # installed version satisfies requested version
     audeer.install_package(
         PACKAGE,
-        version=">=24.2.0",
+        version=">=1.1.0",
     )
     audeer.install_package(
         PACKAGE,
-        version=">24.1.0",
+        version=">1.0.1",
     )
     audeer.install_package(
         PACKAGE,
-        version="<=24.3.0",
+        version="<=1.2.0",
     )
     audeer.install_package(
         PACKAGE,
-        version="  <   24.3.0  ",  # whitespace will be ignored
+        version="  <   1.2.0  ",  # whitespace will be ignored
     )
     audeer.install_package(
         PACKAGE,
@@ -81,20 +77,20 @@ def test():
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">=24.3.0",
+            version=">=1.2.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">24.2.0",
+            version=">1.1.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<=24.1.0",
+            version="<=1.0.1",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<24.2.0",
+            version="<1.1.0",
         )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,8 +7,8 @@ import pytest
 import audeer
 
 
-PACKAGE = "PyYaml"
-MODULE = "yaml"
+PACKAGE = "wrapt"
+MODULE = "wrapt"
 
 
 def uninstall():
@@ -48,25 +48,25 @@ def test():
     # install package
     audeer.install_package(
         PACKAGE,
-        version="<=5.3",
+        version="<=1.16.0",
     )
 
     # installed version satisfies requested version
     audeer.install_package(
         PACKAGE,
-        version=">=5.3",
+        version=">=1.16.0",
     )
     audeer.install_package(
         PACKAGE,
-        version=">5.2",
+        version=">1.15.0",
     )
     audeer.install_package(
         PACKAGE,
-        version="<=6.0",
+        version="<=1.17.0",
     )
     audeer.install_package(
         PACKAGE,
-        version="  <   5.4  ",  # whitespace will be ignored
+        version="  <   1.17.0  ",  # whitespace will be ignored
     )
     audeer.install_package(
         PACKAGE,
@@ -77,20 +77,20 @@ def test():
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">=5.4",
+            version=">=1.17.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">5.3",
+            version=">1.16.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<=5.2",
+            version="<=1.15.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<5.3",
+            version="<1.16.0",
         )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -7,8 +7,12 @@ import pytest
 import audeer
 
 
-PACKAGE = "wrapt"
-MODULE = "wrapt"
+# Package whose distribution name (``attrs``)
+# differs from its import name (``attr``),
+# has no dependencies,
+# and is not a dependency of audeer
+PACKAGE = "attrs"
+MODULE = "attr"
 
 
 def uninstall():
@@ -48,25 +52,25 @@ def test():
     # install package
     audeer.install_package(
         PACKAGE,
-        version="<=1.16.0",
+        version="<=24.2.0",
     )
 
     # installed version satisfies requested version
     audeer.install_package(
         PACKAGE,
-        version=">=1.16.0",
+        version=">=24.2.0",
     )
     audeer.install_package(
         PACKAGE,
-        version=">1.15.0",
+        version=">24.1.0",
     )
     audeer.install_package(
         PACKAGE,
-        version="<=1.17.0",
+        version="<=24.3.0",
     )
     audeer.install_package(
         PACKAGE,
-        version="  <   1.17.0  ",  # whitespace will be ignored
+        version="  <   24.3.0  ",  # whitespace will be ignored
     )
     audeer.install_package(
         PACKAGE,
@@ -77,20 +81,20 @@ def test():
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">=1.17.0",
+            version=">=24.3.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version=">1.16.0",
+            version=">24.2.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<=1.15.0",
+            version="<=24.1.0",
         )
     with pytest.raises(RuntimeError):
         audeer.install_package(
             PACKAGE,
-            version="<1.16.0",
+            version="<24.2.0",
         )


### PR DESCRIPTION
Add `audeer.load_configuration()` to provide a unified way for handling configuration files, including providing a default config file, supporting overriding by user config files and by environment variables.

The new function can then be reused inside `audb` and `audmodel` and will solve https://github.com/audeering/audb/issues/485. 

We need `pyaml` to read the configuration files, but to not add a new default dependency we add it as optonal dependency that you need to enable with `audeer[yaml]` in order to use `audeer.load_configuration()`.

I also update the unrelated `tests/test_install.py` as it used `pyyaml` before in the tests. As this is now a dependency of `audeer`, I switched to [python-dotenv](https://github.com/theskumar/python-dotenv).

<img width="717" height="584" alt="image" src="https://github.com/user-attachments/assets/d9a2d754-e0a2-4620-a9fa-d4bcbce4e687" />

<img width="692" height="763" alt="image" src="https://github.com/user-attachments/assets/bafc8602-6480-49a1-b6d4-30ce041b8625" />
