### PR TITLE
Whole-dict environment overrides (stacked on #196)

### DIFF
--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -43,6 +43,16 @@ def load_configuration(
     by joining the levels with ``__``,
     e.g. ``model.device``
     is overridden by ``<env_prefix>_MODEL__DEVICE``.
+    A whole nested mapping can instead be replaced
+    by a single variable holding a JSON object,
+    e.g. ``<env_prefix>_MODEL='{"device": "cpu"}'``;
+    the object replaces the mapping as a whole
+    (keys it omits are dropped)
+    and may introduce keys not present in the files.
+    Nested variables are applied afterwards
+    and therefore take precedence,
+    e.g. ``<env_prefix>_MODEL__DEVICE``
+    overrides ``device`` from ``<env_prefix>_MODEL``.
     The value of an environment variable is converted
     to the type of the corresponding default value:
     ``str`` values are used as they are,
@@ -248,7 +258,17 @@ def _override_with_environment(
                     f"The 'types' entry for the nested section '{key}' "
                     f"must be a mapping, but is '{type(key_type).__name__}'."
                 )
-            _override_with_environment(default_value, name, key_type or {}, "__")
+            # A whole-section variable (e.g. PKG_MODEL) replaces the mapping
+            # as a JSON object; nested variables (e.g. PKG_MODEL__DEVICE) are
+            # applied afterwards and therefore take precedence.
+            if name in os.environ:
+                cfg[key] = _parse_environment_value(
+                    name,
+                    os.environ[name],
+                    default_value,
+                    dict,
+                )
+            _override_with_environment(cfg[key], name, key_type or {}, "__")
         elif name in os.environ:
             cfg[key] = _parse_environment_value(
                 name,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -189,6 +189,64 @@ def test_load_configuration_environment_nested_unknown_key(tmpdir, monkeypatch):
     assert config == {"model": {"device": "cuda"}}
 
 
+def test_load_configuration_environment_partial_override(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    # Only one nested key is overridden; the other stays as in the file
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {"model": {"device": "cuda", "lora": False}}
+
+
+def test_load_configuration_environment_whole_dict_replace(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    # A whole-section variable replaces the mapping as a JSON object,
+    # so a key it omits (``lora``) is dropped
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda"}')
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {"model": {"device": "cuda"}}
+
+
+def test_load_configuration_environment_whole_dict_introduces_key(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n",
+    )
+    # A whole-dict replace may introduce a key not present in the file
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda", "batch": 8}')
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {"model": {"device": "cuda", "batch": 8}}
+
+
+def test_load_configuration_environment_whole_dict_then_nested(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    # The whole-section variable is applied first,
+    # then the nested variable on top (higher precedence)
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda"}')
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "mps")
+    config = audeer.load_configuration(config_file, env_prefix="PKG")
+    assert config == {"model": {"device": "mps"}}
+
+
+def test_load_configuration_environment_whole_dict_not_object(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n",
+    )
+    # A whole-section variable must be a JSON object
+    monkeypatch.setenv("PKG_MODEL", "5")
+    with pytest.raises(ValueError, match="could not be converted to the type"):
+        audeer.load_configuration(config_file, env_prefix="PKG")
+
+
 def test_load_configuration_environment_bool_false(tmpdir, monkeypatch):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),


### PR DESCRIPTION
Pre-staged follow-up implementing whole-dict environment overrides, discussed in #196.

**Base is the #196 branch** (`config-handling-helper-extras`), so it can be merged
into #196 if we decide to land the feature there; otherwise it stands alone as a
follow-up.

## What it adds

A whole nested mapping can be replaced by a single JSON variable, and nested
variables are layered on top:

- `PKG_MODEL='{"device": "cpu"}'` replaces the whole `model` mapping (keys it
  omits are dropped; it may introduce new keys).
- `PKG_MODEL__DEVICE=cpu` still overrides a single nested key.
- If both are set, the whole-dict variable is applied first and the nested one
  on top (higher precedence) — matching `pydantic-settings`.

Unchanged: only existing config entries are overridable (the whole-dict form is
the one exception, since it carries a full object); `types={"section": dict}`
still raises, since a JSON object is self-describing.

## Tests

Whole-dict replace, key introduction, whole-dict-then-nested precedence,
non-object rejection, and a partial-override case. `config.py` stays at 100%
coverage.

Refs #196.
