### PR TITLE
Accept mapping as user configuration

### DIFF
--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -111,9 +111,8 @@ def load_configuration(
         default_config_file: path to default configuration file.
             The file does not have to exist
         user_configs: path(s) to user configuration file(s),
-            or an already parsed mapping,
-            applied in the given order
-            (a mapping may also appear as part of the sequence).
+            or already parsed mapping(s),
+            applied in the given order.
             Files do not have to exist,
             and a given mapping is not modified
         env_prefix: prefix of environment variables

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -215,11 +215,15 @@ def load_configuration(
 def _copy_mapping(mapping: Mapping) -> dict:
     r"""Copy a mapping into plain dictionaries.
 
-    Nested mappings and lists are copied as well,
+    Nested mappings, lists, and tuples are copied as well,
     so merging and environment overrides
     cannot modify the mapping given by the user.
-    All other values are immutable
-    or are never modified in place.
+    Values of other container types,
+    e.g. a ``set``,
+    are not copied and remain shared with the given mapping.
+    This is not a concern for configuration values
+    parsed from JSON or YAML,
+    which never produce such types.
 
     Args:
         mapping: mapping to copy
@@ -235,8 +239,8 @@ def _copy_value(value: object) -> object:
     r"""Copy a configuration value, see :func:`_copy_mapping`."""
     if isinstance(value, Mapping):
         return _copy_mapping(value)
-    if isinstance(value, list):
-        return [_copy_value(item) for item in value]
+    if isinstance(value, (list, tuple)):
+        return type(value)(_copy_value(item) for item in value)
     return value
 
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -7,7 +7,7 @@ import os
 
 def load_configuration(
     default_config_file: str,
-    user_config_files: str | Mapping | Sequence[str | Mapping] | None = None,
+    user_configs: str | Mapping | Sequence[str | Mapping] | None = None,
     *,
     env_prefix: str | None = None,
     types: Mapping | None = None,
@@ -20,7 +20,7 @@ def load_configuration(
 
     1. ``default_config_file``,
        e.g. the configuration file shipped with a package
-    2. ``user_config_files``,
+    2. ``user_configs``,
        applied in the given order
        (a later entry overrides an earlier one)
     3. environment variables,
@@ -110,7 +110,7 @@ def load_configuration(
     Args:
         default_config_file: path to default configuration file.
             The file does not have to exist
-        user_config_files: path(s) to user configuration file(s),
+        user_configs: path(s) to user configuration file(s),
             or an already parsed mapping,
             applied in the given order
             (a mapping may also appear as part of the sequence).
@@ -187,14 +187,14 @@ def load_configuration(
     """
     cfg = _load_configuration_file(default_config_file)
 
-    if user_config_files is not None:
-        if isinstance(user_config_files, (str, Mapping)):
-            user_config_files = [user_config_files]
-        for user_config_file in user_config_files:
-            if isinstance(user_config_file, Mapping):
-                _deep_merge(cfg, _copy_mapping(user_config_file))
+    if user_configs is not None:
+        if isinstance(user_configs, (str, Mapping)):
+            user_configs = [user_configs]
+        for user_config in user_configs:
+            if isinstance(user_config, Mapping):
+                _deep_merge(cfg, _copy_mapping(user_config))
             else:
-                _deep_merge(cfg, _load_configuration_file(user_config_file))
+                _deep_merge(cfg, _load_configuration_file(user_config))
 
     if types is not None:
         if not isinstance(types, Mapping):

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -192,9 +192,10 @@ def load_configuration(
             user_configs = [user_configs]
         for user_config in user_configs:
             if isinstance(user_config, Mapping):
-                _deep_merge(cfg, _copy_mapping(user_config))
+                update = _copy_mapping(user_config)
             else:
-                _deep_merge(cfg, _load_configuration_file(user_config))
+                update = _load_configuration_file(user_config)
+            _deep_merge(cfg, update)
 
     if types is not None:
         if not isinstance(types, Mapping):

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -85,7 +85,8 @@ def load_configuration(
     (e.g. a date parsed from YAML)
     cannot be overridden
     and raises a ``ValueError`` as well.
-    Only keys already present in the configuration files
+    Only keys already present in the merged configuration,
+    whether from a file or a mapping,
     can be overridden by environment variables.
     Only string keys are matched;
     a non-string key (e.g. a numeric YAML key)
@@ -110,12 +111,11 @@ def load_configuration(
         default_config_file: path to default configuration file.
             The file does not have to exist
         user_config_files: path(s) to user configuration file(s),
-            applied in the given order.
-            Files do not have to exist.
-            An already parsed mapping
-            can be given instead of a file path,
-            also as part of the sequence.
-            It is not modified
+            or an already parsed mapping,
+            applied in the given order
+            (a mapping may also appear as part of the sequence).
+            Files do not have to exist,
+            and a given mapping is not modified
         env_prefix: prefix of environment variables
             used to override configuration values.
             If ``None``, environment variables are ignored

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -7,7 +7,7 @@ import os
 
 def load_configuration(
     default_config_file: str,
-    user_config_files: str | Sequence[str] | None = None,
+    user_config_files: str | Mapping | Sequence[str | Mapping] | None = None,
     *,
     env_prefix: str | None = None,
     types: Mapping | None = None,
@@ -22,7 +22,7 @@ def load_configuration(
        e.g. the configuration file shipped with a package
     2. ``user_config_files``,
        applied in the given order
-       (a later file overrides an earlier one)
+       (a later entry overrides an earlier one)
     3. environment variables,
        if ``env_prefix`` is given
 
@@ -33,6 +33,16 @@ def load_configuration(
     and keeps the remaining keys from the default.
     Any non-mapping value (including a list)
     replaces the previous value as a whole.
+
+    A user configuration
+    may also be given as an already parsed mapping
+    instead of a file path,
+    e.g. a single section
+    of a configuration file
+    that the application has parsed itself
+    and that is shared by several packages.
+    It is deep-merged in the same way as a file,
+    and the given mapping is not modified.
 
     Environment variables are matched
     against the upper-cased configuration keys,
@@ -101,7 +111,11 @@ def load_configuration(
             The file does not have to exist
         user_config_files: path(s) to user configuration file(s),
             applied in the given order.
-            Files do not have to exist
+            Files do not have to exist.
+            An already parsed mapping
+            can be given instead of a file path,
+            also as part of the sequence.
+            It is not modified
         env_prefix: prefix of environment variables
             used to override configuration values.
             If ``None``, environment variables are ignored
@@ -147,6 +161,15 @@ def load_configuration(
         >>> audeer.load_configuration(config_file)
         {'cache_root': '~/cache'}
 
+        A user configuration can also be given
+        as an already parsed mapping.
+
+        >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
+        >>> with open(config_file, "w") as file:
+        ...     _ = file.write("model:\n  device: cpu\n  lora: false\n")
+        >>> audeer.load_configuration(config_file, {"model": {"device": "cuda"}})
+        {'model': {'device': 'cuda', 'lora': False}}
+
         A key that defaults to ``None`` has no inferred type,
         so declare it in ``types``.
 
@@ -165,10 +188,13 @@ def load_configuration(
     cfg = _load_configuration_file(default_config_file)
 
     if user_config_files is not None:
-        if isinstance(user_config_files, str):
+        if isinstance(user_config_files, (str, Mapping)):
             user_config_files = [user_config_files]
         for user_config_file in user_config_files:
-            _deep_merge(cfg, _load_configuration_file(user_config_file))
+            if isinstance(user_config_file, Mapping):
+                _deep_merge(cfg, _copy_mapping(user_config_file))
+            else:
+                _deep_merge(cfg, _load_configuration_file(user_config_file))
 
     if types is not None:
         if not isinstance(types, Mapping):
@@ -184,6 +210,34 @@ def load_configuration(
         validate(cfg)
 
     return cfg
+
+
+def _copy_mapping(mapping: Mapping) -> dict:
+    r"""Copy a mapping into plain dictionaries.
+
+    Nested mappings and lists are copied as well,
+    so merging and environment overrides
+    cannot modify the mapping given by the user.
+    All other values are immutable
+    or are never modified in place.
+
+    Args:
+        mapping: mapping to copy
+
+    Returns:
+        copy of ``mapping``, using ``dict`` at every level
+
+    """
+    return {key: _copy_value(value) for key, value in mapping.items()}
+
+
+def _copy_value(value: object) -> object:
+    r"""Copy a configuration value, see :func:`_copy_mapping`."""
+    if isinstance(value, Mapping):
+        return _copy_mapping(value)
+    if isinstance(value, list):
+        return [_copy_value(item) for item in value]
+    return value
 
 
 def _deep_merge(base: dict, update: dict) -> None:

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -26,23 +26,13 @@ def load_configuration(
     3. environment variables,
        if ``env_prefix`` is given
 
-    Configuration files are deep-merged:
+    Configuration files or mappings are deep-merged:
     nested mappings are merged key by key,
     so a section in a user file
     only overrides the keys it defines
     and keeps the remaining keys from the default.
     Any non-mapping value (including a list)
     replaces the previous value as a whole.
-
-    A user configuration
-    may also be given as an already parsed mapping
-    instead of a file path,
-    e.g. a single section
-    of a configuration file
-    that the application has parsed itself
-    and that is shared by several packages.
-    It is deep-merged in the same way as a file,
-    and the given mapping is not modified.
 
     Environment variables are matched
     against the upper-cased configuration keys,
@@ -215,12 +205,15 @@ def load_configuration(
 def _copy_mapping(mapping: Mapping) -> dict:
     r"""Copy a mapping into plain dictionaries.
 
-    Nested mappings, lists, and tuples are copied as well,
+    Nested mappings, and plain lists and tuples, are copied as well,
     so merging and environment overrides
     cannot modify the mapping given by the user.
     Values of other container types,
-    e.g. a ``set``,
-    are not copied and remain shared with the given mapping.
+    e.g. a ``set`` or a ``NamedTuple``,
+    are not copied and remain shared with the given mapping:
+    a ``NamedTuple`` is a ``tuple`` subclass
+    whose constructor does not accept a single iterable,
+    so it is kept as a leaf value like a set is.
     This is not a concern for configuration values
     parsed from JSON or YAML,
     which never produce such types.
@@ -239,7 +232,7 @@ def _copy_value(value: object) -> object:
     r"""Copy a configuration value, see :func:`_copy_mapping`."""
     if isinstance(value, Mapping):
         return _copy_mapping(value)
-    if isinstance(value, (list, tuple)):
+    if type(value) in (list, tuple):
         return type(value)(_copy_value(item) for item in value)
     return value
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 import pathlib
+from types import MappingProxyType
 
 import pytest
+import yaml
 
 import audeer
 
@@ -194,6 +196,260 @@ def test_load_configuration_multiple_user_files(tmpdir):
         default_file,
         [user_file_1, user_file_2],
     ) == {"cache_root": "~/user2"}
+
+
+def test_load_configuration_user_mapping(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cuda\n  lora: false\n",
+    )
+    # An already parsed mapping is accepted instead of a file path,
+    # and is deep-merged like a file:
+    # a key set only in the default file is kept
+    assert audeer.load_configuration(default_file, {"model": {"device": "cpu"}}) == {
+        "model": {"device": "cpu", "lora": False},
+    }
+
+
+def test_load_configuration_user_mapping_after_file(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    # A sequence may mix file paths and mappings;
+    # the mapping comes last and wins
+    assert audeer.load_configuration(
+        default_file,
+        [user_file, {"cache_root": "~/mapping"}],
+    ) == {"cache_root": "~/mapping"}
+
+
+def test_load_configuration_user_mapping_before_file(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    # The file comes last and wins
+    assert audeer.load_configuration(
+        default_file,
+        [{"cache_root": "~/mapping"}, user_file],
+    ) == {"cache_root": "~/user"}
+
+
+def test_load_configuration_user_mapping_empty(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cuda\n  lora: false\n",
+    )
+    # An empty mapping keeps the default values
+    assert audeer.load_configuration(default_file, {}) == {
+        "model": {"device": "cuda", "lora": False},
+    }
+
+
+def test_load_configuration_user_mapping_adds_new_key(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cuda\n",
+    )
+    user_config = {"model": {"lora": True}, "tts": {"vendor": "iva-tts"}}
+    # A mapping may introduce keys that are not in the default file,
+    # inside a nested section and at the top level
+    assert audeer.load_configuration(default_file, user_config) == {
+        "model": {"device": "cuda", "lora": True},
+        "tts": {"vendor": "iva-tts"},
+    }
+
+
+def test_load_configuration_user_mapping_list_replaced(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "hosts:\n  - a\n  - b\n",
+    )
+    # A list value of the mapping replaces the default list as a whole
+    assert audeer.load_configuration(default_file, {"hosts": ["c"]}) == {
+        "hosts": ["c"],
+    }
+
+
+def test_load_configuration_user_mapping_list_not_modified(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "hosts:\n  - a\n",
+    )
+    user_config = {"hosts": ["b"], "repositories": [{"name": "r1"}]}
+    config = audeer.load_configuration(default_file, user_config)
+    # Lists, and the mappings they contain, are copied as well,
+    # so changing them afterwards
+    # does not change the configuration
+    user_config["hosts"].append("c")
+    user_config["repositories"][0]["name"] = "r2"
+    assert config == {"hosts": ["b"], "repositories": [{"name": "r1"}]}
+
+
+def test_load_configuration_user_mapping_two_mappings(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config_1 = {"model": {"device": "cpu"}}
+    user_config_2 = {"model": {"lora": True}}
+    # Two mappings are deep-merged with each other,
+    # and merging the second one
+    # does not modify the first one
+    config = audeer.load_configuration(default_file, [user_config_1, user_config_2])
+    assert config == {
+        "name": "default",
+        "model": {"device": "cpu", "lora": True},
+    }
+    assert user_config_1 == {"model": {"device": "cpu"}}
+
+
+def test_load_configuration_user_mapping_not_modified(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    # The section is present in the mapping only,
+    # so it would become part of the configuration by reference,
+    # if it was not copied
+    user_config = {"model": {"device": "cpu", "lora": False}}
+    # The mapping given by the caller is not modified,
+    # not even by the environment overrides applied afterwards
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "mps")
+    config = audeer.load_configuration(default_file, user_config, env_prefix="PKG")
+    assert config == {
+        "name": "default",
+        "model": {"device": "mps", "lora": False},
+    }
+    assert user_config == {"model": {"device": "cpu", "lora": False}}
+
+    # The returned configuration is not aliased to the mapping either
+    user_config["model"]["device"] = "xpu"
+    assert config["model"]["device"] == "mps"
+
+
+def test_load_configuration_user_mapping_environment(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config = {"count": 1, "model": {"device": "cpu"}}
+    # A key introduced by the mapping can be overridden
+    # by an environment variable,
+    # also with the nested '__' form,
+    # and is cast to the type of the mapping's value
+    monkeypatch.setenv("PKG_COUNT", "5")
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    config = audeer.load_configuration(default_file, user_config, env_prefix="PKG")
+    assert config == {
+        "name": "default",
+        "count": 5,
+        "model": {"device": "cuda"},
+    }
+    assert isinstance(config["count"], int)
+
+
+def test_load_configuration_user_mapping_environment_json(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config = {"model": {"device": "cpu"}}
+    # A section introduced by the mapping
+    # can be replaced by a JSON environment variable,
+    # and the values of the mapping provide the types for it
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda"}')
+    config = audeer.load_configuration(default_file, user_config, env_prefix="PKG")
+    assert config == {"name": "default", "model": {"device": "cuda"}}
+    monkeypatch.setenv("PKG_MODEL", '{"device": 5}')
+    with pytest.raises(ValueError, match="has type 'str'"):
+        audeer.load_configuration(default_file, user_config, env_prefix="PKG")
+
+
+def test_load_configuration_user_mapping_types(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config = {"timeout": None}
+    # ``types`` is validated after merging,
+    # so it may declare a key that only the mapping introduced
+    monkeypatch.setenv("PKG_TIMEOUT", "2.5")
+    config = audeer.load_configuration(
+        default_file,
+        user_config,
+        env_prefix="PKG",
+        types={"timeout": float},
+    )
+    assert config == {"name": "default", "timeout": 2.5}
+
+
+def test_load_configuration_user_mapping_immutable(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config = MappingProxyType(
+        {"model": MappingProxyType({"device": "cpu", "lora": False})},
+    )
+    # Any mapping is accepted, not only a dictionary.
+    # It is copied into plain dictionaries,
+    # so a nested section can still be overridden
+    # by an environment variable
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    config = audeer.load_configuration(default_file, user_config, env_prefix="PKG")
+    assert config == {
+        "name": "default",
+        "model": {"device": "cuda", "lora": False},
+    }
+
+
+def test_load_configuration_user_mapping_shared_file(tmpdir, monkeypatch):
+    default_file_a = write_config(
+        audeer.path(tmpdir, "default_a.yaml"),
+        "cache_root: ~/cache-a\ntimeout: null\n",
+    )
+    default_file_b = write_config(
+        audeer.path(tmpdir, "default_b.yaml"),
+        "cache_root: ~/cache-b\n",
+    )
+    shared_file = write_config(
+        audeer.path(tmpdir, "shared.yaml"),
+        "lib-a:\n  cache_root: ~/shared-a\nlib-b:\n  cache_root: ~/shared-b\n",
+    )
+    with open(shared_file) as fp:
+        data = yaml.load(fp, Loader=yaml.SafeLoader)
+    # An application parses a shared configuration file itself
+    # and hands each section to the package that owns it,
+    # every package keeping its own defaults, prefix and types
+    monkeypatch.setenv("LIB_A_TIMEOUT", "2.5")
+    monkeypatch.setenv("LIB_B_CACHE_ROOT", "~/env-b")
+    config_a = audeer.load_configuration(
+        default_file_a,
+        data["lib-a"],
+        env_prefix="LIB_A",
+        types={"timeout": float},
+    )
+    config_b = audeer.load_configuration(
+        default_file_b,
+        data["lib-b"],
+        env_prefix="LIB_B",
+    )
+    assert config_a == {"cache_root": "~/shared-a", "timeout": 2.5}
+    assert config_b == {"cache_root": "~/env-b"}
+    assert data == {
+        "lib-a": {"cache_root": "~/shared-a"},
+        "lib-b": {"cache_root": "~/shared-b"},
+    }
 
 
 def test_load_configuration_environment(tmpdir, monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -295,6 +295,19 @@ def test_load_configuration_user_mapping_list_not_modified(tmpdir):
     assert config == {"hosts": ["b"], "repositories": [{"name": "r1"}]}
 
 
+def test_load_configuration_user_mapping_tuple_not_modified(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    user_config = {"t": ({"k": 1},)}
+    config = audeer.load_configuration(default_file, user_config)
+    # A tuple, and the mappings it contains, are copied as well,
+    # so mutating them afterwards does not change the configuration
+    user_config["t"][0]["k"] = 2
+    assert config == {"name": "default", "t": ({"k": 1},)}
+
+
 def test_load_configuration_user_mapping_two_mappings(tmpdir):
     default_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import collections
 import pathlib
 from types import MappingProxyType
 
@@ -306,6 +307,20 @@ def test_load_configuration_user_mapping_tuple_not_modified(tmpdir):
     # so mutating them afterwards does not change the configuration
     user_config["t"][0]["k"] = 2
     assert config == {"name": "default", "t": ({"k": 1},)}
+
+
+def test_load_configuration_user_mapping_named_tuple_not_copied(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "name: default\n",
+    )
+    Point = collections.namedtuple("Point", ["x", "y"])
+    point = Point(x=1, y=2)
+    # A NamedTuple is a tuple subclass but its constructor does not accept
+    # a single iterable, so it is treated like a set: kept as a leaf value,
+    # not copied
+    config = audeer.load_configuration(default_file, {"position": point})
+    assert config == {"name": "default", "position": point}
 
 
 def test_load_configuration_user_mapping_two_mappings(tmpdir):


### PR DESCRIPTION
Part 1 of #197 — the uncontroversial half, split out per hagenw's request in
[#197 (comment)](https://github.com/audeering/audeer/issues/197#issuecomment-5128236235).

`user_config_files` now accepts `str | Mapping | Sequence[str | Mapping]`
instead of only file paths, per the signature hagenw proposed in
[#197 (comment)](https://github.com/audeering/audeer/issues/197#issuecomment-5103562212).
This lets an application parse a configuration file shared by several
packages once and hand each section to the package that owns it:

```python
data = yaml.safe_load(open("config.yaml"))
cfg_a = lib_a.load_config(data["lib-a"])   # lib_a still owns its schema/defaults/prefix
cfg_b = lib_b.load_config(data["lib-b"])
```

`user_config_files` already accepted a bare `str` or a `Sequence[str]`; a
mapping follows the same bare-or-sequence shape, so it can stand alone or sit
next to file paths (and other mappings) in the sequence, rather than being a
special one-off case.

A mapping is deep-merged exactly like a file (same precedence, same
scalar/section rules) and is copied into plain dictionaries before merging,
so neither the merge nor later environment overrides can modify the mapping
given by the caller — including nested sections, lists, and tuples.

Part 2 (effective-config provenance) is intentionally not part of this PR;
still being discussed on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)