### PR TITLE
Effective-config tracking for load_configuration()

### DIFF
--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -12,6 +12,7 @@ def load_configuration(
     env_prefix: str | None = None,
     types: Mapping | None = None,
     validate: Callable[[dict], None] | None = None,
+    tracking: dict | None = None,
 ) -> dict:
     r"""Load configuration from files and environment variables.
 
@@ -120,6 +121,39 @@ def load_configuration(
             dictionary and raises an error if it is invalid.
             It is applied once,
             after files and environment variables are merged
+        tracking: dict that records,
+            for each configuration key,
+            which layer set its effective value.
+            ``tracking`` mirrors the (possibly nested) structure
+            of the returned configuration,
+            and each leaf is a label naming its source:
+            ``"default"`` for ``default_config_file``,
+            the path of the ``user_configs`` entry
+            that provided a file,
+            ``"mapping[<i>]"`` for the ``user_configs`` entry
+            at index ``<i>`` that provided an already parsed mapping
+            (indices count every entry of the sequence,
+            file or mapping alike),
+            or the exact environment variable name
+            (e.g. ``"PKG_MODEL__DEVICE"``)
+            for an environment variable override.
+            A whole-section JSON environment variable
+            labels every key it sets;
+            a more specific nested variable applied afterwards
+            re-labels only the key it overrides,
+            leaving its siblings labeled by the section variable.
+            Entries are added to ``tracking`` in place,
+            exactly like ``dict.update()``;
+            it is never cleared first.
+            Pass a fresh ``{}`` for a clean view of a single call,
+            or reuse the same dict across several calls
+            to accumulate their entries.
+            ``tracking`` never influences the returned configuration,
+            it only records how it was assembled.
+            If ``None`` (the default),
+            no tracking is performed
+            and calling ``load_configuration()``
+            costs the same as without this argument
 
     Returns:
         merged configuration dictionary
@@ -173,18 +207,46 @@ def load_configuration(
         {'hosts': ['host1', 'host2']}
         >>> del os.environ["APP_HOSTS"]
 
+        ``tracking`` records which layer set each key's effective value.
+
+        >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
+        >>> with open(config_file, "w") as file:
+        ...     _ = file.write("cache_root: ~/cache\n")
+        >>> tracking = {}
+        >>> audeer.load_configuration(
+        ...     config_file, {"cache_root": "~/user"}, tracking=tracking
+        ... )
+        {'cache_root': '~/user'}
+        >>> tracking
+        {'cache_root': 'mapping[0]'}
+
     """
     cfg = _load_configuration_file(default_config_file)
+
+    # Tracking is a genuine structural no-op when off: ``owner`` stays
+    # ``None``, so ``_deep_merge()``/``_override_with_environment()`` below
+    # run exactly the same path they always did, and no tracking tree is
+    # ever built. A non-``dict`` value (e.g. passed in error) is treated the
+    # same as ``None`` rather than crashing on an unrelated ``.update()``.
+    owner: dict | None = None
+    if isinstance(tracking, dict):
+        owner = _label_tree(cfg, "default")
 
     if user_configs is not None:
         if isinstance(user_configs, (str, Mapping)):
             user_configs = [user_configs]
-        for user_config in user_configs:
+        for i, user_config in enumerate(user_configs):
             if isinstance(user_config, Mapping):
                 update = _copy_mapping(user_config)
             else:
                 update = _load_configuration_file(user_config)
-            _deep_merge(cfg, update)
+            if owner is None:
+                _deep_merge(cfg, update)
+            else:
+                label = (
+                    f"mapping[{i}]" if isinstance(user_config, Mapping) else user_config
+                )
+                _deep_merge(cfg, update, owner, label)
 
     if types is not None:
         if not isinstance(types, Mapping):
@@ -194,10 +256,13 @@ def load_configuration(
         _validate_types(cfg, types)
 
     if env_prefix is not None:
-        _override_with_environment(cfg, f"{env_prefix}_", types or {})
+        _override_with_environment(cfg, f"{env_prefix}_", types or {}, owner)
 
     if validate is not None:
         validate(cfg)
+
+    if owner is not None:
+        tracking.update(owner)
 
     return cfg
 
@@ -237,7 +302,40 @@ def _copy_value(value: object) -> object:
     return value
 
 
-def _deep_merge(base: dict, update: dict) -> None:
+def _label_tree(mapping: Mapping, label: str) -> dict:
+    r"""Build a tracking tree that attributes every key to ``label``.
+
+    Mirrors the (possibly nested) structure of ``mapping``,
+    replacing every leaf value with ``label``.
+    Used both for the initial tracking tree
+    (every key starts out attributed to the default file)
+    and to expand a single label into a per-leaf tree,
+    e.g. when a whole configuration section
+    is replaced by a JSON environment variable
+    and a more specific, nested variable
+    later overrides one of its keys.
+
+    Args:
+        mapping: mapping whose structure is mirrored
+        label: label assigned to every leaf
+
+    Returns:
+        tracking tree, the same shape as ``mapping``,
+        with ``label`` at every leaf
+
+    """
+    return {
+        key: _label_tree(value, label) if isinstance(value, Mapping) else label
+        for key, value in mapping.items()
+    }
+
+
+def _deep_merge(
+    base: dict,
+    update: Mapping,
+    owner: dict | None = None,
+    label: str | None = None,
+) -> None:
     r"""Recursively merge ``update`` into ``base`` in place.
 
     Nested mappings are merged key by key,
@@ -246,9 +344,21 @@ def _deep_merge(base: dict, update: dict) -> None:
     Any non-mapping value (including lists)
     replaces the corresponding value in ``base``.
 
+    When ``owner`` is given,
+    it is updated in place to mirror ``base``:
+    a key that is merged key by key (recursion)
+    keeps or creates a nested dict in ``owner``,
+    and a key that is replaced wholesale
+    (a scalar, a list, or a mapping introduced fresh)
+    is attributed to ``label`` at every leaf of its subtree.
+
     Args:
         base: dictionary to merge into
         update: dictionary whose values take precedence
+        owner: tracking tree mirroring ``base``,
+            updated in place when given
+        label: label attributed to keys set or replaced by ``update``,
+            used only when ``owner`` is given
 
     """
     for key, value in update.items():
@@ -257,9 +367,20 @@ def _deep_merge(base: dict, update: dict) -> None:
             and isinstance(base[key], Mapping)
             and isinstance(value, Mapping)
         ):
-            _deep_merge(base[key], value)
+            if owner is None:
+                _deep_merge(base[key], value)
+            else:
+                # ``base[key]`` is a mapping, so ``owner[key]`` is
+                # already a matching nested dict: either from the
+                # initial tracking tree, or set by an earlier iteration
+                # of this same loop (see the ``else`` branch below)
+                _deep_merge(base[key], value, owner[key], label)
         else:
             base[key] = value
+            if owner is not None:
+                owner[key] = (
+                    _label_tree(value, label) if isinstance(value, Mapping) else label
+                )
 
 
 def _load_configuration_file(config_file: str) -> dict:
@@ -444,6 +565,7 @@ def _override_with_environment(
     cfg: dict,
     env_prefix: str,
     types: Mapping,
+    owner: dict | None = None,
 ) -> None:
     r"""Override configuration values with environment variables in place.
 
@@ -453,6 +575,21 @@ def _override_with_environment(
     e.g. ``model.device`` with prefix ``PKG``
     is overridden by ``PKG_MODEL__DEVICE``.
 
+    When ``owner`` is given,
+    it is updated in place to mirror ``cfg``:
+    a key overridden by an environment variable
+    is attributed to that variable's exact name.
+    The key is already known at this point,
+    since it is what the variable name is built from,
+    so no attribution is ever derived
+    by reversing a variable name back into a key.
+    A whole-section JSON replacement
+    attributes every one of its leaves
+    to the section variable;
+    a more specific, nested variable
+    applied afterwards then re-attributes
+    only the one leaf it overrides.
+
     Args:
         cfg: configuration dictionary, modified in place
         env_prefix: name prefix accumulated so far,
@@ -460,6 +597,8 @@ def _override_with_environment(
             (``PKG_`` at the top level, ``PKG_MODEL__`` below)
         types: declared types mirroring ``cfg``,
             used to cast values whose default is ``None``
+        owner: tracking tree mirroring ``cfg``,
+            updated in place when given
 
     """
     for key, default_value in cfg.items():
@@ -491,7 +630,14 @@ def _override_with_environment(
                     key_type or {},
                 )
                 cfg[key] = parsed
-            _override_with_environment(cfg[key], f"{name}__", key_type or {})
+                if owner is not None:
+                    owner[key] = _label_tree(parsed, name)
+            _override_with_environment(
+                cfg[key],
+                f"{name}__",
+                key_type or {},
+                owner[key] if owner is not None else None,
+            )
         elif name in os.environ:
             cfg[key] = _parse_environment_value(
                 name,
@@ -499,11 +645,20 @@ def _override_with_environment(
                 default_value,
                 key_type,
             )
+            if owner is not None:
+                owner[key] = name
             if isinstance(cfg[key], Mapping):
                 # A mapping introduced via a declared ``dict`` type
                 # behaves like a section, so nested variables
                 # are applied on top of it as well
-                _override_with_environment(cfg[key], f"{name}__", {})
+                if owner is not None:
+                    owner[key] = _label_tree(cfg[key], name)
+                _override_with_environment(
+                    cfg[key],
+                    f"{name}__",
+                    {},
+                    owner[key] if owner is not None else None,
+                )
 
 
 def _parse_environment_value(

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -649,8 +649,6 @@ def _override_with_environment(
                 default_value,
                 key_type,
             )
-            if owner is not None:
-                owner[key] = f"env:{name}"
             if isinstance(cfg[key], Mapping):
                 # A mapping introduced via a declared ``dict`` type
                 # behaves like a section, so nested variables
@@ -663,6 +661,8 @@ def _override_with_environment(
                     {},
                     owner[key] if owner is not None else None,
                 )
+            elif owner is not None:
+                owner[key] = f"env:{name}"
 
 
 def _parse_environment_value(

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -147,7 +147,7 @@ def load_configuration(
             exactly like ``dict.update()``;
             it is never cleared first.
             Pass a fresh ``{}`` for a clean view of a single call,
-            or reuse the same dict across several calls
+            or reuse the same mapping across several calls
             to accumulate their entries.
             ``tracking`` never influences the returned configuration,
             it only records how it was assembled.

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -129,14 +129,14 @@ def load_configuration(
             of the returned configuration,
             and each leaf is a label naming its source:
             ``"default"`` for ``default_config_file``,
-            the path of the ``user_configs`` entry
+            ``f"file:{path}"`` for the ``user_configs`` entry
             that provided a file,
             ``"mapping[<i>]"`` for the ``user_configs`` entry
             at index ``<i>`` that provided an already parsed mapping
             (indices count every entry of the sequence,
             file or mapping alike),
-            or the exact environment variable name
-            (e.g. ``"PKG_MODEL__DEVICE"``)
+            or ``f"env:{name}"`` naming the exact environment variable
+            (e.g. ``"env:PKG_MODEL__DEVICE"``)
             for an environment variable override.
             A whole-section JSON environment variable
             labels every key it sets;
@@ -249,7 +249,9 @@ def load_configuration(
                 _deep_merge(cfg, update)
             else:
                 label = (
-                    f"mapping[{i}]" if isinstance(user_config, Mapping) else user_config
+                    f"mapping[{i}]"
+                    if isinstance(user_config, Mapping)
+                    else f"file:{user_config}"
                 )
                 _deep_merge(cfg, update, owner, label)
 
@@ -636,7 +638,7 @@ def _override_with_environment(
                 )
                 cfg[key] = parsed
                 if owner is not None:
-                    owner[key] = _label_tree(parsed, name)
+                    owner[key] = _label_tree(parsed, f"env:{name}")
             _override_with_environment(
                 cfg[key],
                 f"{name}__",
@@ -651,13 +653,13 @@ def _override_with_environment(
                 key_type,
             )
             if owner is not None:
-                owner[key] = name
+                owner[key] = f"env:{name}"
             if isinstance(cfg[key], Mapping):
                 # A mapping introduced via a declared ``dict`` type
                 # behaves like a section, so nested variables
                 # are applied on top of it as well
                 if owner is not None:
-                    owner[key] = _label_tree(cfg[key], name)
+                    owner[key] = _label_tree(cfg[key], f"env:{name}")
                 _override_with_environment(
                     cfg[key],
                     f"{name}__",

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -164,6 +164,7 @@ def load_configuration(
             is not a mapping
         ValueError: if a ``types`` entry
             does not match any configuration key
+        ValueError: if ``tracking`` is not a mutable mapping
 
     Examples:
         >>> import tempfile

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -210,23 +210,6 @@ def load_configuration(
         {'model': {'device': 'env:PKG_MODEL__DEVICE', 'lora': 'file:...config.yaml'}}
         >>> del os.environ["PKG_MODEL__DEVICE"]
 
-        Passing the same ``tracking`` mapping to a second call
-        accumulates its entries instead of overwriting them.
-
-        >>> default_file_a = audeer.path(tempfile.mkdtemp(), "a.yaml")
-        >>> with open(default_file_a, "w") as file:
-        ...     _ = file.write("cache_root: ~/cache\n")
-        >>> default_file_b = audeer.path(tempfile.mkdtemp(), "b.yaml")
-        >>> with open(default_file_b, "w") as file:
-        ...     _ = file.write("pool_size: 4\n")
-        >>> tracking = {}
-        >>> audeer.load_configuration(default_file_a, tracking=tracking)
-        {'cache_root': '~/cache'}
-        >>> audeer.load_configuration(default_file_b, tracking=tracking)
-        {'pool_size': 4}
-        >>> tracking
-        {'cache_root': 'file:...a.yaml', 'pool_size': 'file:...b.yaml'}
-
     """
     cfg = _load_configuration_file(default_config_file)
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -225,6 +225,23 @@ def load_configuration(
         {'model': {'device': 'env:PKG_MODEL__DEVICE', 'lora': 'default'}}
         >>> del os.environ["PKG_MODEL__DEVICE"]
 
+        Passing the same ``tracking`` mapping to a second call
+        accumulates its entries instead of overwriting them.
+
+        >>> default_file_a = audeer.path(tempfile.mkdtemp(), "a.yaml")
+        >>> with open(default_file_a, "w") as file:
+        ...     _ = file.write("cache_root: ~/cache\n")
+        >>> default_file_b = audeer.path(tempfile.mkdtemp(), "b.yaml")
+        >>> with open(default_file_b, "w") as file:
+        ...     _ = file.write("pool_size: 4\n")
+        >>> tracking = {}
+        >>> audeer.load_configuration(default_file_a, tracking=tracking)
+        {'cache_root': '~/cache'}
+        >>> audeer.load_configuration(default_file_b, tracking=tracking)
+        {'pool_size': 4}
+        >>> tracking
+        {'cache_root': 'default', 'pool_size': 'default'}
+
     """
     cfg = _load_configuration_file(default_config_file)
 

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -124,10 +124,7 @@ def load_configuration(
             after files and environment variables are merged
         tracking: mutable mapping that records,
             for each configuration key,
-            which layer set its effective value.
-            ``tracking`` mirrors the (possibly nested) structure
-            of the returned configuration,
-            and each leaf is a label naming its source:
+            which layer set its effective value:
             ``f"file:{path}"`` for ``default_config_file``
             or a ``user_configs`` entry that provided a file,
             ``"mapping[<i>]"`` for the ``user_configs`` entry
@@ -139,21 +136,13 @@ def load_configuration(
             for an environment variable override.
             A whole-section JSON environment variable
             labels every key it sets;
-            a more specific nested variable applied afterwards
-            re-labels only the key it overrides,
-            leaving its siblings labeled by the section variable.
-            Entries are added to ``tracking`` in place,
-            exactly like ``dict.update()``;
-            it is never cleared first.
-            Pass a fresh ``{}`` for a clean view of a single call,
-            or reuse the same mapping across several calls
+            a more specific nested variable re-labels
+            only the key it overrides.
+            Entries are added to ``tracking`` in place.
+            Reuse the same mapping across several calls
             to accumulate their entries.
-            ``tracking`` never influences the returned configuration,
-            it only records how it was assembled.
-            If ``None`` (the default),
+            If ``None``,
             no tracking is performed
-            and calling ``load_configuration()``
-            costs the same as without this argument
 
     Returns:
         merged configuration dictionary
@@ -207,11 +196,7 @@ def load_configuration(
         {'hosts': ['host1', 'host2']}
         >>> del os.environ["APP_HOSTS"]
 
-        ``tracking`` records which layer set each key's effective value,
-        mirroring the (possibly nested) structure of the configuration.
-        A key untouched by any later layer keeps the default file's
-        own ``"file:"`` label, even a nested key sitting right next to
-        a sibling that an environment variable does override.
+        ``tracking`` records which layer set each key's effective value.
 
         >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
         >>> with open(config_file, "w") as file:

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -208,18 +208,22 @@ def load_configuration(
         {'hosts': ['host1', 'host2']}
         >>> del os.environ["APP_HOSTS"]
 
-        ``tracking`` records which layer set each key's effective value.
+        ``tracking`` records which layer set each key's effective value,
+        mirroring the (possibly nested) structure of the configuration.
+        A key untouched by any later layer keeps ``"default"``,
+        even a nested key sitting right next to a sibling
+        that an environment variable does override.
 
         >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
         >>> with open(config_file, "w") as file:
-        ...     _ = file.write("cache_root: ~/cache\n")
+        ...     _ = file.write("model:\n  device: cpu\n  lora: false\n")
+        >>> os.environ["PKG_MODEL__DEVICE"] = "cuda"
         >>> tracking = {}
-        >>> audeer.load_configuration(
-        ...     config_file, {"cache_root": "~/user"}, tracking=tracking
-        ... )
-        {'cache_root': '~/user'}
+        >>> audeer.load_configuration(config_file, env_prefix="PKG", tracking=tracking)
+        {'model': {'device': 'cuda', 'lora': False}}
         >>> tracking
-        {'cache_root': 'mapping[0]'}
+        {'model': {'device': 'env:PKG_MODEL__DEVICE', 'lora': 'default'}}
+        >>> del os.environ["PKG_MODEL__DEVICE"]
 
     """
     cfg = _load_configuration_file(default_config_file)

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from collections.abc import Mapping
+from collections.abc import MutableMapping
 from collections.abc import Sequence
 import json
 import os
@@ -12,7 +13,7 @@ def load_configuration(
     env_prefix: str | None = None,
     types: Mapping | None = None,
     validate: Callable[[dict], None] | None = None,
-    tracking: dict | None = None,
+    tracking: MutableMapping | None = None,
 ) -> dict:
     r"""Load configuration from files and environment variables.
 
@@ -121,7 +122,7 @@ def load_configuration(
             dictionary and raises an error if it is invalid.
             It is applied once,
             after files and environment variables are merged
-        tracking: dict that records,
+        tracking: mutable mapping that records,
             for each configuration key,
             which layer set its effective value.
             ``tracking`` mirrors the (possibly nested) structure
@@ -223,9 +224,9 @@ def load_configuration(
     """
     cfg = _load_configuration_file(default_config_file)
 
-    if tracking is not None and not isinstance(tracking, dict):
+    if tracking is not None and not isinstance(tracking, MutableMapping):
         raise ValueError(
-            f"'tracking' must be a dict, but is '{type(tracking).__name__}'."
+            f"'tracking' must be a mutable mapping, but is '{type(tracking).__name__}'."
         )
 
     # Tracking is a genuine structural no-op when off: ``owner`` stays

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -128,9 +128,8 @@ def load_configuration(
             ``tracking`` mirrors the (possibly nested) structure
             of the returned configuration,
             and each leaf is a label naming its source:
-            ``"default"`` for ``default_config_file``,
-            ``f"file:{path}"`` for the ``user_configs`` entry
-            that provided a file,
+            ``f"file:{path}"`` for ``default_config_file``
+            or a ``user_configs`` entry that provided a file,
             ``"mapping[<i>]"`` for the ``user_configs`` entry
             at index ``<i>`` that provided an already parsed mapping
             (indices count every entry of the sequence,
@@ -210,9 +209,9 @@ def load_configuration(
 
         ``tracking`` records which layer set each key's effective value,
         mirroring the (possibly nested) structure of the configuration.
-        A key untouched by any later layer keeps ``"default"``,
-        even a nested key sitting right next to a sibling
-        that an environment variable does override.
+        A key untouched by any later layer keeps the default file's
+        own ``"file:"`` label, even a nested key sitting right next to
+        a sibling that an environment variable does override.
 
         >>> config_file = audeer.path(tempfile.mkdtemp(), "config.yaml")
         >>> with open(config_file, "w") as file:
@@ -222,7 +221,7 @@ def load_configuration(
         >>> audeer.load_configuration(config_file, env_prefix="PKG", tracking=tracking)
         {'model': {'device': 'cuda', 'lora': False}}
         >>> tracking
-        {'model': {'device': 'env:PKG_MODEL__DEVICE', 'lora': 'default'}}
+        {'model': {'device': 'env:PKG_MODEL__DEVICE', 'lora': 'file:...config.yaml'}}
         >>> del os.environ["PKG_MODEL__DEVICE"]
 
         Passing the same ``tracking`` mapping to a second call
@@ -240,7 +239,7 @@ def load_configuration(
         >>> audeer.load_configuration(default_file_b, tracking=tracking)
         {'pool_size': 4}
         >>> tracking
-        {'cache_root': 'default', 'pool_size': 'default'}
+        {'cache_root': 'file:...a.yaml', 'pool_size': 'file:...b.yaml'}
 
     """
     cfg = _load_configuration_file(default_config_file)
@@ -256,7 +255,7 @@ def load_configuration(
     # ever built.
     owner: dict | None = None
     if tracking is not None:
-        owner = _label_tree(cfg, "default")
+        owner = _label_tree(cfg, f"file:{default_config_file}")
 
     if user_configs is not None:
         if isinstance(user_configs, (str, Mapping)):

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -223,13 +223,17 @@ def load_configuration(
     """
     cfg = _load_configuration_file(default_config_file)
 
+    if tracking is not None and not isinstance(tracking, dict):
+        raise ValueError(
+            f"'tracking' must be a dict, but is '{type(tracking).__name__}'."
+        )
+
     # Tracking is a genuine structural no-op when off: ``owner`` stays
     # ``None``, so ``_deep_merge()``/``_override_with_environment()`` below
     # run exactly the same path they always did, and no tracking tree is
-    # ever built. A non-``dict`` value (e.g. passed in error) is treated the
-    # same as ``None`` rather than crashing on an unrelated ``.update()``.
+    # ever built.
     owner: dict | None = None
-    if isinstance(tracking, dict):
+    if tracking is not None:
         owner = _label_tree(cfg, "default")
 
     if user_configs is not None:

--- a/audeer/core/config.py
+++ b/audeer/core/config.py
@@ -373,20 +373,16 @@ def _deep_merge(
     replaces the corresponding value in ``base``.
 
     When ``owner`` is given,
-    it is updated in place to mirror ``base``:
-    a key that is merged key by key (recursion)
-    keeps or creates a nested dict in ``owner``,
-    and a key that is replaced wholesale
-    (a scalar, a list, or a mapping introduced fresh)
-    is attributed to ``label`` at every leaf of its subtree.
+    it is updated in place like ``base``.
 
     Args:
         base: dictionary to merge into
         update: dictionary whose values take precedence
-        owner: tracking tree mirroring ``base``,
-            updated in place when given
-        label: label attributed to keys set or replaced by ``update``,
-            used only when ``owner`` is given
+        owner: owner tracking dictionary to merge into
+        label: label attributed to keys set or replaced by ``update``.
+            Every key ``update`` touches in this call gets the same
+            ``label``, since they all come from the same source.
+            Required when ``owner`` is given
 
     """
     for key, value in update.items():
@@ -401,7 +397,7 @@ def _deep_merge(
                 # ``base[key]`` is a mapping, so ``owner[key]`` is
                 # already a matching nested dict: either from the
                 # initial tracking tree, or set by an earlier iteration
-                # of this same loop (see the ``else`` branch below)
+                # of this same loop
                 _deep_merge(base[key], value, owner[key], label)
         else:
             base[key] = value
@@ -607,10 +603,6 @@ def _override_with_environment(
     it is updated in place to mirror ``cfg``:
     a key overridden by an environment variable
     is attributed to that variable's exact name.
-    The key is already known at this point,
-    since it is what the variable name is built from,
-    so no attribution is ever derived
-    by reversing a variable name back into a key.
     A whole-section JSON replacement
     attributes every one of its leaves
     to the section variable;
@@ -625,8 +617,7 @@ def _override_with_environment(
             (``PKG_`` at the top level, ``PKG_MODEL__`` below)
         types: declared types mirroring ``cfg``,
             used to cast values whose default is ``None``
-        owner: tracking tree mirroring ``cfg``,
-            updated in place when given
+        owner: owner tracking dictionary, updated in place when given
 
     """
     for key, default_value in cfg.items():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1538,6 +1538,32 @@ def test_load_configuration_tracking_untouched_on_error(tmpdir, monkeypatch):
     assert tracking == {"preexisting": "sentinel"}
 
 
+def test_load_configuration_tracking_key_overridden_by_every_layer(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\nshared: /data\ntimeout: 1\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "shared: /user-data\ntimeout: 2\n",
+    )
+    monkeypatch.setenv("PKG_TIMEOUT", "3")
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file, user_file, env_prefix="PKG", tracking=tracking
+    )
+    # "cache_root" is set only by the default file, "shared" is overridden
+    # once (by the user file), and "timeout" is overridden by every layer
+    # in turn: tracking must show the outermost layer that actually
+    # touched each key, not an intermediate one
+    assert config == {"cache_root": "~/cache", "shared": "/user-data", "timeout": 3}
+    assert tracking == {
+        "cache_root": "default",
+        "shared": f"file:{user_file}",
+        "timeout": "env:PKG_TIMEOUT",
+    }
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import collections
+from collections import UserDict
 import pathlib
 from types import MappingProxyType
 
@@ -1262,14 +1263,26 @@ def test_load_configuration_tracking_none(tmpdir):
     assert type(config) is dict
 
 
-def test_load_configuration_tracking_not_a_dict(tmpdir):
+def test_load_configuration_tracking_not_a_mutable_mapping(tmpdir):
     default_file = write_config(
         audeer.path(tmpdir, "default.yaml"),
         "cache_root: ~/cache\n",
     )
-    # ``tracking`` must be a dict, like ``types`` must be a mapping
-    with pytest.raises(ValueError, match="must be a dict"):
-        audeer.load_configuration(default_file, tracking="not-a-dict")
+    # ``tracking`` must be a mutable mapping, like ``types`` must be a mapping
+    with pytest.raises(ValueError, match="must be a mutable mapping"):
+        audeer.load_configuration(default_file, tracking="not-a-mapping")
+
+
+def test_load_configuration_tracking_user_dict(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    # A ``MutableMapping`` that is not a ``dict`` subclass is accepted too
+    tracking = UserDict()
+    config = audeer.load_configuration(default_file, tracking=tracking)
+    assert config == {"cache_root": "~/cache"}
+    assert dict(tracking) == {"cache_root": "default"}
 
 
 def test_load_configuration_tracking_default_only_key(tmpdir):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1564,6 +1564,32 @@ def test_load_configuration_tracking_key_overridden_by_every_layer(tmpdir, monke
     }
 
 
+def test_load_configuration_tracking_merge_into_freshly_introduced_section(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file,
+        [{"tts": {"vendor": "iva-tts"}}, {"tts": {"region": "eu"}}],
+        tracking=tracking,
+    )
+    # The default file has no "tts" section at all: the first mapping
+    # entry introduces it fresh, and the second entry deep-merges an
+    # additional key into that same section. At that point owner["tts"]
+    # was set by the first entry's iteration, not by the initial tracking
+    # tree built from the default file
+    assert config == {
+        "cache_root": "~/cache",
+        "tts": {"vendor": "iva-tts", "region": "eu"},
+    }
+    assert tracking == {
+        "cache_root": "default",
+        "tts": {"vendor": "mapping[0]", "region": "mapping[1]"},
+    }
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1511,6 +1511,33 @@ def test_load_configuration_tracking_does_not_affect_cfg(tmpdir, monkeypatch):
     assert config_without == config_with
 
 
+def test_load_configuration_tracking_untouched_on_error(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\ntimeout: null\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    monkeypatch.setenv("PKG_TIMEOUT", "not-a-number")
+    tracking = {"preexisting": "sentinel"}
+    # By the time the environment override raises, the internal tracking
+    # tree already holds real entries built from the default file and
+    # ``user_file``. None of that leaks into the caller's ``tracking``
+    # mapping: it is only ever updated once, as the very last step, after
+    # every other step succeeded
+    with pytest.raises(ValueError, match="could not be converted"):
+        audeer.load_configuration(
+            default_file,
+            user_file,
+            env_prefix="PKG",
+            types={"timeout": float},
+            tracking=tracking,
+        )
+    assert tracking == {"preexisting": "sentinel"}
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1282,7 +1282,7 @@ def test_load_configuration_tracking_user_dict(tmpdir):
     tracking = UserDict()
     config = audeer.load_configuration(default_file, tracking=tracking)
     assert config == {"cache_root": "~/cache"}
-    assert dict(tracking) == {"cache_root": "default"}
+    assert dict(tracking) == {"cache_root": f"file:{default_file}"}
 
 
 def test_load_configuration_tracking_default_only_key(tmpdir):
@@ -1292,9 +1292,9 @@ def test_load_configuration_tracking_default_only_key(tmpdir):
     )
     tracking = {}
     config = audeer.load_configuration(default_file, tracking=tracking)
-    # A key that no later layer touches is attributed to "default"
+    # A key that no later layer touches is attributed to the default file
     assert config == {"cache_root": "~/cache"}
-    assert tracking == {"cache_root": "default"}
+    assert tracking == {"cache_root": f"file:{default_file}"}
 
 
 def test_load_configuration_tracking_user_file(tmpdir):
@@ -1309,9 +1309,12 @@ def test_load_configuration_tracking_user_file(tmpdir):
     tracking = {}
     config = audeer.load_configuration(default_file, user_file, tracking=tracking)
     # A user config file is labeled by its own path,
-    # the untouched key stays attributed to "default"
+    # the untouched key stays attributed to the default file's path
     assert config == {"cache_root": "~/user", "shared": "/data"}
-    assert tracking == {"cache_root": f"file:{user_file}", "shared": "default"}
+    assert tracking == {
+        "cache_root": f"file:{user_file}",
+        "shared": f"file:{default_file}",
+    }
 
 
 def test_load_configuration_tracking_user_mapping(tmpdir):
@@ -1329,7 +1332,7 @@ def test_load_configuration_tracking_user_mapping(tmpdir):
     # (normalized) sequence; deep-merged keys keep their own attribution
     assert config == {"model": {"device": "cpu", "lora": False}}
     assert tracking == {
-        "model": {"device": "mapping[0]", "lora": "default"},
+        "model": {"device": "mapping[0]", "lora": f"file:{default_file}"},
     }
 
 
@@ -1367,7 +1370,7 @@ def test_load_configuration_tracking_environment_scalar(tmpdir, monkeypatch):
     # A scalar environment override is labeled by the exact variable name
     assert config == {"model": {"device": "cuda", "lora": False}}
     assert tracking == {
-        "model": {"device": "env:PKG_MODEL__DEVICE", "lora": "default"},
+        "model": {"device": "env:PKG_MODEL__DEVICE", "lora": f"file:{default_file}"},
     }
 
 
@@ -1437,7 +1440,7 @@ def test_load_configuration_tracking_accumulates_across_calls(tmpdir, monkeypatc
     assert config_a == {"cache_root": "~/cache-a", "timeout": 2.5}
     assert config_b == {"pool_size": 8}
     assert tracking == {
-        "cache_root": "default",
+        "cache_root": f"file:{default_file_a}",
         "timeout": "env:LIB_A_TIMEOUT",
         "pool_size": "env:LIB_B_POOL_SIZE",
     }
@@ -1558,7 +1561,7 @@ def test_load_configuration_tracking_key_overridden_by_every_layer(tmpdir, monke
     # touched each key, not an intermediate one
     assert config == {"cache_root": "~/cache", "shared": "/user-data", "timeout": 3}
     assert tracking == {
-        "cache_root": "default",
+        "cache_root": f"file:{default_file}",
         "shared": f"file:{user_file}",
         "timeout": "env:PKG_TIMEOUT",
     }
@@ -1585,7 +1588,7 @@ def test_load_configuration_tracking_merge_into_freshly_introduced_section(tmpdi
         "tts": {"vendor": "iva-tts", "region": "eu"},
     }
     assert tracking == {
-        "cache_root": "default",
+        "cache_root": f"file:{default_file}",
         "tts": {"vendor": "mapping[0]", "region": "mapping[1]"},
     }
 
@@ -1623,10 +1626,15 @@ def test_load_configuration_tracking_three_levels_deep(tmpdir, monkeypatch):
     # This checks the recursion through _label_tree(), _deep_merge(), and
     # _override_with_environment() actually holds three levels deep: the
     # overridden leaf is attributed to its variable, the untouched sibling
-    # at the same depth keeps "default"
+    # at the same depth keeps its "file:" label
     assert config == {"model": {"gpu": {"device": "mps", "memory": 8}}}
     assert tracking == {
-        "model": {"gpu": {"device": "env:PKG_MODEL__GPU__DEVICE", "memory": "default"}},
+        "model": {
+            "gpu": {
+                "device": "env:PKG_MODEL__GPU__DEVICE",
+                "memory": f"file:{default_file}",
+            },
+        },
     }
 
 
@@ -1645,7 +1653,7 @@ def test_load_configuration_tracking_multiple_mapping_entries(tmpdir):
     # counted by sequence position, not just "some mapping touched it"
     assert config == {"cache_root": "~/cache", "a": 1, "b": 2, "c": 3}
     assert tracking == {
-        "cache_root": "default",
+        "cache_root": f"file:{default_file}",
         "a": "mapping[0]",
         "b": "mapping[1]",
         "c": "mapping[2]",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1609,6 +1609,27 @@ def test_load_configuration_tracking_section_collapsed_to_scalar(tmpdir):
     assert tracking == {"model": "mapping[0]"}
 
 
+def test_load_configuration_tracking_three_levels_deep(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  gpu:\n    device: cuda\n    memory: 8\n",
+    )
+    monkeypatch.setenv("PKG_MODEL__GPU__DEVICE", "mps")
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file, env_prefix="PKG", tracking=tracking
+    )
+    # Every existing nested test stops at one level (e.g. "model.device").
+    # This checks the recursion through _label_tree(), _deep_merge(), and
+    # _override_with_environment() actually holds three levels deep: the
+    # overridden leaf is attributed to its variable, the untouched sibling
+    # at the same depth keeps "default"
+    assert config == {"model": {"gpu": {"device": "mps", "memory": 8}}}
+    assert tracking == {
+        "model": {"gpu": {"device": "env:PKG_MODEL__GPU__DEVICE", "memory": "default"}},
+    }
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1311,7 +1311,7 @@ def test_load_configuration_tracking_user_file(tmpdir):
     # A user config file is labeled by its own path,
     # the untouched key stays attributed to "default"
     assert config == {"cache_root": "~/user", "shared": "/data"}
-    assert tracking == {"cache_root": user_file, "shared": "default"}
+    assert tracking == {"cache_root": f"file:{user_file}", "shared": "default"}
 
 
 def test_load_configuration_tracking_user_mapping(tmpdir):
@@ -1367,7 +1367,7 @@ def test_load_configuration_tracking_environment_scalar(tmpdir, monkeypatch):
     # A scalar environment override is labeled by the exact variable name
     assert config == {"model": {"device": "cuda", "lora": False}}
     assert tracking == {
-        "model": {"device": "PKG_MODEL__DEVICE", "lora": "default"},
+        "model": {"device": "env:PKG_MODEL__DEVICE", "lora": "default"},
     }
 
 
@@ -1383,7 +1383,7 @@ def test_load_configuration_tracking_environment_whole_dict(tmpdir, monkeypatch)
     # to the one variable that replaced the section
     assert config == {"model": {"device": "cuda", "lora": True}}
     assert tracking == {
-        "model": {"device": "PKG_MODEL", "lora": "PKG_MODEL"},
+        "model": {"device": "env:PKG_MODEL", "lora": "env:PKG_MODEL"},
     }
 
 
@@ -1404,7 +1404,7 @@ def test_load_configuration_tracking_environment_whole_dict_then_nested(
     # "device" is re-attributed to the more specific variable,
     # "lora" (untouched by it) stays attributed to the section variable
     assert tracking == {
-        "model": {"device": "PKG_MODEL__DEVICE", "lora": "PKG_MODEL"},
+        "model": {"device": "env:PKG_MODEL__DEVICE", "lora": "env:PKG_MODEL"},
     }
 
 
@@ -1438,8 +1438,8 @@ def test_load_configuration_tracking_accumulates_across_calls(tmpdir, monkeypatc
     assert config_b == {"pool_size": 8}
     assert tracking == {
         "cache_root": "default",
-        "timeout": "LIB_A_TIMEOUT",
-        "pool_size": "LIB_B_POOL_SIZE",
+        "timeout": "env:LIB_A_TIMEOUT",
+        "pool_size": "env:LIB_B_POOL_SIZE",
     }
 
 
@@ -1461,7 +1461,7 @@ def test_load_configuration_tracking_types_none_default_environment(
         tracking=tracking,
     )
     assert config == {"timeout": 2.5}
-    assert tracking == {"timeout": "PKG_TIMEOUT"}
+    assert tracking == {"timeout": "env:PKG_TIMEOUT"}
 
 
 def test_load_configuration_tracking_environment_declared_dict_then_nested(
@@ -1485,7 +1485,7 @@ def test_load_configuration_tracking_environment_declared_dict_then_nested(
     )
     assert config == {"model": {"device": "cuda", "batch": 8}}
     assert tracking == {
-        "model": {"device": "PKG_MODEL__DEVICE", "batch": "PKG_MODEL"},
+        "model": {"device": "env:PKG_MODEL__DEVICE", "batch": "env:PKG_MODEL"},
     }
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1238,6 +1238,269 @@ def test_load_configuration_environment_invalid(
         audeer.load_configuration(config_file, env_prefix="PKG")
 
 
+def test_load_configuration_tracking_omitted(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    # Without ``tracking``, the return value is the plain configuration
+    # dictionary, exactly as before the feature existed
+    config = audeer.load_configuration(default_file)
+    assert config == {"cache_root": "~/cache"}
+    assert type(config) is dict
+
+
+def test_load_configuration_tracking_none(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    # ``tracking=None`` is explicitly the same as omitting it:
+    # a structural no-op, not "compute it and throw it away"
+    config = audeer.load_configuration(default_file, tracking=None)
+    assert config == {"cache_root": "~/cache"}
+    assert type(config) is dict
+
+
+def test_load_configuration_tracking_off_skips_bookkeeping(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    # A non-dict, non-None ``tracking`` value is never touched when the
+    # feature is off: no ``.update()`` (or similar) is attempted on it, so
+    # passing a string does not raise. This shows the tracking-only branch
+    # never executes unless ``tracking`` is a real dict
+    config = audeer.load_configuration(default_file, tracking="not-a-dict")
+    assert config == {"cache_root": "~/cache"}
+
+
+def test_load_configuration_tracking_default_only_key(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(default_file, tracking=tracking)
+    # A key that no later layer touches is attributed to "default"
+    assert config == {"cache_root": "~/cache"}
+    assert tracking == {"cache_root": "default"}
+
+
+def test_load_configuration_tracking_user_file(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\nshared: /data\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(default_file, user_file, tracking=tracking)
+    # A user config file is labeled by its own path,
+    # the untouched key stays attributed to "default"
+    assert config == {"cache_root": "~/user", "shared": "/data"}
+    assert tracking == {"cache_root": user_file, "shared": "default"}
+
+
+def test_load_configuration_tracking_user_mapping(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cuda\n  lora: false\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file,
+        {"model": {"device": "cpu"}},
+        tracking=tracking,
+    )
+    # A mapping in ``user_configs`` is labeled by its index in the
+    # (normalized) sequence; deep-merged keys keep their own attribution
+    assert config == {"model": {"device": "cpu", "lora": False}}
+    assert tracking == {
+        "model": {"device": "mapping[0]", "lora": "default"},
+    }
+
+
+def test_load_configuration_tracking_user_configs_mixed_sequence(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "cache_root: ~/user\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file,
+        [user_file, {"cache_root": "~/mapping"}],
+        tracking=tracking,
+    )
+    # The mapping's index reflects its position in the sequence,
+    # not the count of mapping entries alone
+    assert config == {"cache_root": "~/mapping"}
+    assert tracking == {"cache_root": "mapping[1]"}
+
+
+def test_load_configuration_tracking_environment_scalar(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file, env_prefix="PKG", tracking=tracking
+    )
+    # A scalar environment override is labeled by the exact variable name
+    assert config == {"model": {"device": "cuda", "lora": False}}
+    assert tracking == {
+        "model": {"device": "PKG_MODEL__DEVICE", "lora": "default"},
+    }
+
+
+def test_load_configuration_tracking_environment_whole_dict(tmpdir, monkeypatch):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda", "lora": true}')
+    tracking = {}
+    config = audeer.load_configuration(config_file, env_prefix="PKG", tracking=tracking)
+    # A whole-section JSON replace attributes every leaf it sets
+    # to the one variable that replaced the section
+    assert config == {"model": {"device": "cuda", "lora": True}}
+    assert tracking == {
+        "model": {"device": "PKG_MODEL", "lora": "PKG_MODEL"},
+    }
+
+
+def test_load_configuration_tracking_environment_whole_dict_then_nested(
+    tmpdir, monkeypatch
+):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    # The whole-section variable sets both keys, then a more specific
+    # nested variable overrides just "device" afterwards
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cuda", "lora": true}')
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "mps")
+    tracking = {}
+    config = audeer.load_configuration(config_file, env_prefix="PKG", tracking=tracking)
+    assert config == {"model": {"device": "mps", "lora": True}}
+    # "device" is re-attributed to the more specific variable,
+    # "lora" (untouched by it) stays attributed to the section variable
+    assert tracking == {
+        "model": {"device": "PKG_MODEL__DEVICE", "lora": "PKG_MODEL"},
+    }
+
+
+def test_load_configuration_tracking_accumulates_across_calls(tmpdir, monkeypatch):
+    default_file_a = write_config(
+        audeer.path(tmpdir, "default_a.yaml"),
+        "cache_root: ~/cache-a\ntimeout: null\n",
+    )
+    default_file_b = write_config(
+        audeer.path(tmpdir, "default_b.yaml"),
+        "pool_size: 4\n",
+    )
+    monkeypatch.setenv("LIB_A_TIMEOUT", "2.5")
+    monkeypatch.setenv("LIB_B_POOL_SIZE", "8")
+    tracking = {}
+    # Two independent calls sharing the same ``tracking`` dict:
+    # like ``dict.update()``, entries from both calls are kept,
+    # the second call does not wipe out the first
+    config_a = audeer.load_configuration(
+        default_file_a,
+        env_prefix="LIB_A",
+        types={"timeout": float},
+        tracking=tracking,
+    )
+    config_b = audeer.load_configuration(
+        default_file_b,
+        env_prefix="LIB_B",
+        tracking=tracking,
+    )
+    assert config_a == {"cache_root": "~/cache-a", "timeout": 2.5}
+    assert config_b == {"pool_size": 8}
+    assert tracking == {
+        "cache_root": "default",
+        "timeout": "LIB_A_TIMEOUT",
+        "pool_size": "LIB_B_POOL_SIZE",
+    }
+
+
+def test_load_configuration_tracking_types_none_default_environment(
+    tmpdir, monkeypatch
+):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "timeout: null\n",
+    )
+    monkeypatch.setenv("PKG_TIMEOUT", "2.5")
+    tracking = {}
+    # A key declared in ``types`` because its default is ``None``
+    # is still attributed to the environment variable that overrides it
+    config = audeer.load_configuration(
+        default_file,
+        env_prefix="PKG",
+        types={"timeout": float},
+        tracking=tracking,
+    )
+    assert config == {"timeout": 2.5}
+    assert tracking == {"timeout": "PKG_TIMEOUT"}
+
+
+def test_load_configuration_tracking_environment_declared_dict_then_nested(
+    tmpdir, monkeypatch
+):
+    config_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model: null\n",
+    )
+    # A None default declared as ``dict`` is introduced by one variable,
+    # then refined by a nested one, exactly like without tracking;
+    # both are attributed to the variable that actually set them
+    monkeypatch.setenv("PKG_MODEL", '{"device": "cpu", "batch": 8}')
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    tracking = {}
+    config = audeer.load_configuration(
+        config_file,
+        env_prefix="PKG",
+        types={"model": dict},
+        tracking=tracking,
+    )
+    assert config == {"model": {"device": "cuda", "batch": 8}}
+    assert tracking == {
+        "model": {"device": "PKG_MODEL__DEVICE", "batch": "PKG_MODEL"},
+    }
+
+
+def test_load_configuration_tracking_does_not_affect_cfg(tmpdir, monkeypatch):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cpu\n  lora: false\n",
+    )
+    user_file = write_config(
+        audeer.path(tmpdir, "user.yaml"),
+        "model:\n  lora: true\n",
+    )
+    monkeypatch.setenv("PKG_MODEL__DEVICE", "cuda")
+    # The exact same call, once with tracking, once without,
+    # must produce an identical configuration:
+    # ``tracking`` is a pure side channel
+    config_without = audeer.load_configuration(
+        default_file, user_file, env_prefix="PKG"
+    )
+    config_with = audeer.load_configuration(
+        default_file, user_file, env_prefix="PKG", tracking={}
+    )
+    assert config_without == config_with
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1262,17 +1262,14 @@ def test_load_configuration_tracking_none(tmpdir):
     assert type(config) is dict
 
 
-def test_load_configuration_tracking_off_skips_bookkeeping(tmpdir):
+def test_load_configuration_tracking_not_a_dict(tmpdir):
     default_file = write_config(
         audeer.path(tmpdir, "default.yaml"),
         "cache_root: ~/cache\n",
     )
-    # A non-dict, non-None ``tracking`` value is never touched when the
-    # feature is off: no ``.update()`` (or similar) is attempted on it, so
-    # passing a string does not raise. This shows the tracking-only branch
-    # never executes unless ``tracking`` is a real dict
-    config = audeer.load_configuration(default_file, tracking="not-a-dict")
-    assert config == {"cache_root": "~/cache"}
+    # ``tracking`` must be a dict, like ``types`` must be a mapping
+    with pytest.raises(ValueError, match="must be a dict"):
+        audeer.load_configuration(default_file, tracking="not-a-dict")
 
 
 def test_load_configuration_tracking_default_only_key(tmpdir):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1630,6 +1630,28 @@ def test_load_configuration_tracking_three_levels_deep(tmpdir, monkeypatch):
     }
 
 
+def test_load_configuration_tracking_multiple_mapping_entries(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "cache_root: ~/cache\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file,
+        [{"a": 1}, {"b": 2}, {"c": 3}],
+        tracking=tracking,
+    )
+    # Three mapping-only entries, no file mixed in: each index must be
+    # counted by sequence position, not just "some mapping touched it"
+    assert config == {"cache_root": "~/cache", "a": 1, "b": 2, "c": 3}
+    assert tracking == {
+        "cache_root": "default",
+        "a": "mapping[0]",
+        "b": "mapping[1]",
+        "c": "mapping[2]",
+    }
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1590,6 +1590,25 @@ def test_load_configuration_tracking_merge_into_freshly_introduced_section(tmpdi
     }
 
 
+def test_load_configuration_tracking_section_collapsed_to_scalar(tmpdir):
+    default_file = write_config(
+        audeer.path(tmpdir, "default.yaml"),
+        "model:\n  device: cuda\n  lora: false\n",
+    )
+    tracking = {}
+    config = audeer.load_configuration(
+        default_file,
+        {"model": "none"},
+        tracking=tracking,
+    )
+    # A scalar in a later layer replaces a whole default section wholesale:
+    # the previously nested per-leaf attribution ("device", "lora") must
+    # collapse into a single flat label for "model", not leave stale
+    # nested entries behind
+    assert config == {"model": "none"}
+    assert tracking == {"model": "mapping[0]"}
+
+
 def test_load_configuration_validate(tmpdir):
     config_file = write_config(
         audeer.path(tmpdir, "default.yaml"),


### PR DESCRIPTION
Relates to #201

Adds `tracking` to `load_configuration()`: a keyword-only mutable mapping that records which layer set each configuration key's effective value.

```python
tracking = {}
cfg = audeer.load_configuration(default_config_file, user_configs, env_prefix="PKG", tracking=tracking)
```

### Changes

- Add `tracking: MutableMapping | None = None` to `load_configuration()`
- Raise `ValueError` for a `tracking` value that is neither a mutable mapping nor `None`, matching `types=`'s own validation — this was a bug in the initial commit (silently treated any garbage value as "off" instead of raising), fixed in 9c38281
- Accept any `MutableMapping`, not only `dict` — consistent with `user_configs`/`types` already being typed as `Mapping` rather than `dict` — fixed in b324341
- Prefix `tracking` labels with `file:`/`env:` to match #201 and the spike (`"default"` and `mapping[<i>]` were already correct; file and environment-variable labels were missing their prefixes) — fixed in a70028d
- Stamp ownership directly inside `_override_with_environment()`, at the point it already holds the real key, instead of reconstructing a key from an environment variable's name (validated as ambiguous and crash-prone on a throwaway spike, [`provenance-tier0-spike`](https://github.com/audeering/audeer/tree/provenance-tier0-spike))

`tracking=None` (the default) is a genuine no-op, costing existing callers nothing. Passing a mapping adds entries into it in place, like `dict.update()` — reusing the same one across calls accumulates, matching the `scipy.io.loadmat(mdict=...)` pattern hagenw cited on #201.

Stacked on #200 (`user_configs`/`Mapping` support) — targets `user-config-mapping`, will need retargeting once #200 merges.

Verified: 614 tests passing, 100% coverage, ruff/pre-commit/Sphinx docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)