### PR TITLE
Rename ruff hook id to ruff-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.13.3
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
ruff-pre-commit renamed the lint hook to `ruff-check` (to read symmetrically with the existing `ruff-format` hook) and kept `ruff` working as a deprecated alias. Silences the "(legacy alias)" notice pre-commit now prints for the old id.

Verified: `uvx pre-commit run --all-files` passes clean, hook now displays as `ruff check` instead of `ruff (legacy alias)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)