### PR TITLE
Let only the Test workflow save the shared uv cache

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html -W

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:
-        cache-suffix: ${{ github.workflow }}
+        save-cache: false
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html -W

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:
-        cache-suffix: ${{ github.workflow }}
+        save-cache: false
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,8 @@ jobs:
     
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
       with:
-        cache-suffix: ${{ github.workflow }}
+        save-cache: false
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Sync Python environment
       run: uv sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
-      with:
-        cache-suffix: ${{ github.workflow }}
 
     - name: Sync Python environment
       run: uv sync


### PR DESCRIPTION
## Problem

Every workflow in this repo installs uv via `astral-sh/setup-uv`,
and each one derives the same cache key — same runner OS, same Python version,
same dependency-file hash. When a single push triggers several workflows at
once, they all try to reserve that one key, and only the first to finish can
save it. The others log:

```
Failed to save: Unable to reserve cache with key setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.13-5899ac3c8d62f4b9cac3f78a0d08699f23e7082de0032680922a422d775c3ad4, another job may be creating this cache.
```

Two live examples, both from the **same push to `main`** — note the identical
cache key in each, which is the collision itself:

| Workflow | Job | Run |
| --- | --- | --- |
| Documentation | `build (ubuntu-latest, 3.12)` | [30991884303](https://github.com/audeering/audeer/actions/runs/30991884303) |
| Linter | `build` | [30991884412](https://github.com/audeering/audeer/actions/runs/30991884412) |

Both failed to reserve, so a third workflow from that same push won the race.

The warning is harmless in itself — the losing job's cache content would have
been byte-identical to the winner's, and nothing fails. It is pure log noise,
but it appears on most pushes and obscures annotations that do matter.

## Fix

Keep the single shared cache key, but let only one workflow write it:
Documentation, Linter and Publish set `save-cache: false` on their `setup-uv`
step (the input is available in v9.0.0), while Test — the job with the fullest
environment — remains the sole saver. With one writer there is no reservation
race and no warning, cross-workflow cache sharing is preserved, and only a
single cache entry is stored.

## Trade-off

After a cache-key rotation (e.g. a `pyproject.toml` change), Documentation and
Linter miss the cache until the next Test run saves the new key — a one-run
cold start costing roughly a second or two per job.

## Context

This is a gap-closing change. This PR started as a per-workflow-cache draft
(`cache-suffix: ${{ github.workflow }}`) and pivoted to the single-saver
design after review feedback: per-workflow suffixes would have stored several
near-identical caches and given up cross-workflow sharing. `audeer` had
already merged audeering/audeer#206 before the warning was diagnosed, so it
never received a fix. The same gap exists in `opensmile-python`, `audformat`
and `audb`, and each will get the same single-saver pattern in a follow-up PR.

## Test plan

- [ ] CI green
- [ ] No `Unable to reserve cache` annotation on any job of this PR's runs
